### PR TITLE
Update winrm_session.py

### DIFF
--- a/contents/winrm_session.py
+++ b/contents/winrm_session.py
@@ -65,7 +65,7 @@ class Session(object):
         return rs
 
     def _clean_error_msg(self, msg):
-        if msg.startswith(b"#< CLIXML\r\n") or "<Objs Version=" in msg:
+        if msg.startswith(b"#< CLIXML\r\n") or "<Objs Version=" or "-1</PI><PC>" in msg:
             new_msg = ""
             msg_xml = msg[11:]
             try:


### PR DESCRIPTION
Adding string to exclude extra powershell noise anything that starts with  "-1</PI><PC>" in msg.