### PR TITLE
Issue 15 fix

### DIFF
--- a/contents/winrm-filecopier.py
+++ b/contents/winrm-filecopier.py
@@ -7,6 +7,7 @@ import time
 import common
 import requests.packages.urllib3
 import logging
+import ntpath
 
 requests.packages.urllib3.disable_warnings()
 
@@ -175,7 +176,7 @@ session = winrm.Session(target=endpoint,
 copy = CopyFiles(session)
 
 destination = args.destination
-filename = os.path.basename(args.source)
+filename = ntpath.basename(args.destination)
 
 if filename in args.destination:
     destination = destination.replace(filename, '')


### PR DESCRIPTION
I was having the same issue as in issue #15  and was able to resolve with the following changes.  When trying to upload and execute a local script on a remote node, Rundeck creates destination file path to be prefaced by job number and node name.  By using the source path as the base for the filename, it was chopping off the job number and turning that into a new directory.  When trying to execute the script, the uploaded file is then in a different path than expected.  I also had issues when using os.path library on a Linux host so I added the more specific ntpath library for windows specific paths.