### PR TITLE
allow custom python interpreter

### DIFF
--- a/contents/wrapper.sh
+++ b/contents/wrapper.sh
@@ -1,0 +1,4 @@
+#!/bin/sh
+PYTHON=${RD_CONFIG_INTERPRETER:-python}
+cd `dirname $0`
+${PYTHON} -u "$@"

--- a/plugin.yaml
+++ b/plugin.yaml
@@ -18,10 +18,17 @@ providers:
     description: Executing Scripts or Commands on remote Windows computer
     service: NodeExecutor
     plugin-type: script
-    script-interpreter: python -u
-    script-file: winrm-exec.py
-    script-args: ${node.hostname}
+    script-interpreter: /bin/sh
+    script-file: wrapper.sh
+    script-args: winrm-exec.py ${node.hostname}
     config:
+      - name: interpreter
+        title: Python Interpreter
+        description: "Python Interpreter (Default: python)"
+        type: String
+        default: "python"
+        required: true
+        scope: Instance
       - name: authtype
         title: Authentication Type
         description: "Authentication Type"
@@ -136,10 +143,17 @@ providers:
     description: Copying files to remote Windows computer
     service: FileCopier
     plugin-type: script
-    script-interpreter: python -u
-    script-file: winrm-filecopier.py
-    script-args: ${node.hostname} ${file-copy.file} ${file-copy.destination}
+    script-interpreter: /bin/sh
+    script-file: wrapper.sh
+    script-args: winrm-filecopier.py ${node.hostname} ${file-copy.file} ${file-copy.destination}
     config:
+      - name: interpreter
+        title: Python Interpreter
+        description: "Python Interpreter (Default: python)"
+        type: String
+        default: "python"
+        required: true
+        scope: Instance
       - name: authtype
         title: Authentication Type
         description: "Authentication Type"
@@ -247,10 +261,17 @@ providers:
     description: Check the connection with a remote node using winrm-python
     service: WorkflowStep
     plugin-type: script
-    script-interpreter: python -u
-    script-args: "--username ${config.username} --hostname ${config.hostname} --password ${config.password_storage_path} --authentication ${config.authtype} --transport ${config.winrmtransport} --port ${config.winrmport} --nossl ${config.nossl} --debug ${config.debug} --certpath ${config.certpath}"
-    script-file: winrm-check.py
+    script-interpreter: /bin/sh
+    script-file: wrapper.sh
+    script-args: winrm-check.py --username ${config.username} --hostname ${config.hostname} --password ${config.password_storage_path} --authentication ${config.authtype} --transport ${config.winrmtransport} --port ${config.winrmport} --nossl ${config.nossl} --debug ${config.debug} --certpath ${config.certpath}
     config:
+      - name: interpreter
+        title: Python Interpreter
+        description: "Python Interpreter (Default: python)"
+        type: String
+        default: "python"
+        required: true
+        scope: Instance
       - name: hostname
         title: Hostname
         description: "Window's Hostname"


### PR DESCRIPTION
This implementation allows the user to point to a custom python interpreter (e.g.: inside a virtualenv).

### Usage example

![image](https://user-images.githubusercontent.com/457100/63951789-c1437d00-ca54-11e9-85e9-e1d273a9cdd9.png)

![image](https://user-images.githubusercontent.com/457100/63951959-0f588080-ca55-11e9-8bd9-fd1aa604cb01.png)


Fixes: #34