### PR TITLE
replace gcc for python-devel

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,7 +107,7 @@ $ pip install pexpect
 
 #### for RHEL/CentOS/etc:
 ```
-$ sudo yum install gcc krb5-devel krb5-workstation
+$ sudo yum install python-devel krb5-devel krb5-workstation
 $ pip install pywinrm[kerberos]
 $ pip install pexpect
 ```


### PR DESCRIPTION
replace gcc for python-devel, centos needs other libraries included on the package python-devel to compile pywinrm[kerberos]

```
[root@node01 rundeck]# pip install pywinrm[kerberos]
DEPRECATION: Python 2.7 will reach the end of its life on January 1st, 2020. Please upgrade your Python as Python 2.7 won't be maintained after that date. A future version of pip will drop support for Python 2.7. More details about Python 2 support in pip, can be found at https://pip.pypa.io/en/latest/development/release-process/#python-2-support
Requirement already satisfied: pywinrm[kerberos] in /usr/lib/python2.7/site-packages (0.4.1)
Requirement already satisfied: xmltodict in /usr/lib/python2.7/site-packages (from pywinrm[kerberos]) (0.12.0)
Requirement already satisfied: requests>=2.9.1 in /usr/lib/python2.7/site-packages (from pywinrm[kerberos]) (2.22.0)
Requirement already satisfied: requests_ntlm>=0.3.0 in /usr/lib/python2.7/site-packages (from pywinrm[kerberos]) (1.1.0)
Requirement already satisfied: six in /usr/lib/python2.7/site-packages (from pywinrm[kerberos]) (1.13.0)
Collecting pykerberos<2.0.0,>=1.2.1
  Using cached https://files.pythonhosted.org/packages/9a/b8/1ec56b6fa8a2e2a81420bd3d90e70b59fc83f6b857fb2c2c37accddc8be3/pykerberos-1.2.1.tar.gz
Requirement already satisfied: chardet<3.1.0,>=3.0.2 in /usr/lib/python2.7/site-packages (from requests>=2.9.1->pywinrm[kerberos]) (3.0.4)
Requirement already satisfied: idna<2.9,>=2.5 in /usr/lib/python2.7/site-packages (from requests>=2.9.1->pywinrm[kerberos]) (2.8)
Requirement already satisfied: urllib3!=1.25.0,!=1.25.1,<1.26,>=1.21.1 in /usr/lib/python2.7/site-packages (from requests>=2.9.1->pywinrm[kerberos]) (1.25.7)
Requirement already satisfied: certifi>=2017.4.17 in /usr/lib/python2.7/site-packages (from requests>=2.9.1->pywinrm[kerberos]) (2019.11.28)
Requirement already satisfied: ntlm-auth>=1.0.2 in /usr/lib/python2.7/site-packages (from requests_ntlm>=0.3.0->pywinrm[kerberos]) (1.4.0)
Requirement already satisfied: cryptography>=1.3 in /usr/lib64/python2.7/site-packages (from requests_ntlm>=0.3.0->pywinrm[kerberos]) (2.8)
Requirement already satisfied: enum34; python_version < "3" in /usr/lib/python2.7/site-packages (from cryptography>=1.3->requests_ntlm>=0.3.0->pywinrm[kerberos]) (1.1.6)
Requirement already satisfied: cffi!=1.11.3,>=1.8 in /usr/lib64/python2.7/site-packages (from cryptography>=1.3->requests_ntlm>=0.3.0->pywinrm[kerberos]) (1.13.2)
Requirement already satisfied: ipaddress; python_version < "3" in /usr/lib/python2.7/site-packages (from cryptography>=1.3->requests_ntlm>=0.3.0->pywinrm[kerberos]) (1.0.16)
Requirement already satisfied: pycparser in /usr/lib/python2.7/site-packages (from cffi!=1.11.3,>=1.8->cryptography>=1.3->requests_ntlm>=0.3.0->pywinrm[kerberos]) (2.19)
Installing collected packages: pykerberos
    Running setup.py install for pykerberos ... error
    ERROR: Command errored out with exit status 1:
     command: /usr/bin/python2 -u -c 'import sys, setuptools, tokenize; sys.argv[0] = '"'"'/tmp/pip-install-wV3ukv/pykerberos/setup.py'"'"'; __file__='"'"'/tmp/pip-install-wV3ukv/pykerberos/setup.py'"'"';f=getattr(tokenize, '"'"'open'"'"', open)(__file__);code=f.read().replace('"'"'\r\n'"'"', '"'"'\n'"'"');f.close();exec(compile(code, __file__, '"'"'exec'"'"'))' install --record /tmp/pip-record-FwZCqT/install-record.txt --single-version-externally-managed --compile
         cwd: /tmp/pip-install-wV3ukv/pykerberos/
    Complete output (13 lines):
    running install
    running build
    running build_ext
    building 'kerberos' extension
    creating build
    creating build/temp.linux-x86_64-2.7
    creating build/temp.linux-x86_64-2.7/src
    gcc -pthread -fno-strict-aliasing -O2 -g -pipe -Wall -Wp,-D_FORTIFY_SOURCE=2 -fexceptions -fstack-protector-strong --param=ssp-buffer-size=4 -grecord-gcc-switches -m64 -mtune=generic -D_GNU_SOURCE -fPIC -fwrapv -DNDEBUG -O2 -g -pipe -Wall -Wp,-D_FORTIFY_SOURCE=2 -fexceptions -fstack-protector-strong --param=ssp-buffer-size=4 -grecord-gcc-switches -m64 -mtune=generic -D_GNU_SOURCE -fPIC -fwrapv -fPIC -I/usr/include/python2.7 -c src/kerberos.c -o build/temp.linux-x86_64-2.7/src/kerberos.o -DGSSAPI_EXT
    src/kerberos.c:17:20: fatal error: Python.h: No such file or directory
     #include <Python.h>
                        ^
    compilation terminated.
    error: command 'gcc' failed with exit status 1
    ----------------------------------------
ERROR: Command errored out with exit status 1: /usr/bin/python2 -u -c 'import sys, setuptools, tokenize; sys.argv[0] = '"'"'/tmp/pip-install-wV3ukv/pykerberos/setup.py'"'"'; __file__='"'"'/tmp/pip-install-wV3ukv/pykerberos/setup.py'"'"';f=getattr(tokenize, '"'"'open'"'"', open)(__file__);code=f.read().replace('"'"'\r\n'"'"', '"'"'\n'"'"');f.close();exec(compile(code, __file__, '"'"'exec'"'"'))' install --record /tmp/pip-record-FwZCqT/install-record.txt --single-version-externally-managed --compile Check the logs for full command output.
WARNING: You are using pip version 19.3.1; however, version 20.0.1 is available.
You should consider upgrading via the 'pip install --upgrade pip' command.
```

```
[root@node01 rundeck]# yum install python-devel
Failed to set locale, defaulting to C
Loaded plugins: fastestmirror
Loading mirror speeds from cached hostfile
 * base: mirror.orbyta.com
 * epel: d2lzkl7pfhq30w.cloudfront.net
 * extras: mirror.orbyta.com
 * updates: mirror.orbyta.com
Resolving Dependencies
--> Running transaction check
---> Package python-devel.x86_64 0:2.7.5-86.el7 will be installed
--> Processing Dependency: python2-rpm-macros > 3-30 for package: python-devel-2.7.5-86.el7.x86_64
--> Processing Dependency: python-rpm-macros > 3-30 for package: python-devel-2.7.5-86.el7.x86_64
--> Running transaction check
---> Package python-rpm-macros.noarch 0:3-32.el7 will be installed
--> Processing Dependency: python-srpm-macros for package: python-rpm-macros-3-32.el7.noarch
---> Package python2-rpm-macros.noarch 0:3-32.el7 will be installed
--> Running transaction check
---> Package python-srpm-macros.noarch 0:3-32.el7 will be installed
--> Finished Dependency Resolution

Dependencies Resolved

========================================================================================================================
 Package                             Arch                    Version                        Repository             Size
========================================================================================================================
Installing:
 python-devel                        x86_64                  2.7.5-86.el7                   base                  398 k
Installing for dependencies:
 python-rpm-macros                   noarch                  3-32.el7                       base                  8.8 k
 python-srpm-macros                  noarch                  3-32.el7                       base                  8.4 k
 python2-rpm-macros                  noarch                  3-32.el7                       base                  7.7 k

Transaction Summary
========================================================================================================================
Install  1 Package (+3 Dependent packages)

Total download size: 423 k
Installed size: 1.1 M
Is this ok [y/d/N]: y
Downloading packages:
(1/4): python-srpm-macros-3-32.el7.noarch.rpm                                                    | 8.4 kB  00:00:00
(2/4): python-rpm-macros-3-32.el7.noarch.rpm                                                     | 8.8 kB  00:00:00
(3/4): python2-rpm-macros-3-32.el7.noarch.rpm                                                    | 7.7 kB  00:00:00
(4/4): python-devel-2.7.5-86.el7.x86_64.rpm                                                      | 398 kB  00:00:01
------------------------------------------------------------------------------------------------------------------------
Total                                                                                   303 kB/s | 423 kB  00:00:01
Running transaction check
Running transaction test
Transaction test succeeded
Running transaction
  Installing : python2-rpm-macros-3-32.el7.noarch                                                                   1/4
  Installing : python-srpm-macros-3-32.el7.noarch                                                                   2/4
  Installing : python-rpm-macros-3-32.el7.noarch                                                                    3/4
  Installing : python-devel-2.7.5-86.el7.x86_64                                                                     4/4
  Verifying  : python-rpm-macros-3-32.el7.noarch                                                                    1/4
  Verifying  : python-srpm-macros-3-32.el7.noarch                                                                   2/4
  Verifying  : python2-rpm-macros-3-32.el7.noarch                                                                   3/4
  Verifying  : python-devel-2.7.5-86.el7.x86_64                                                                     4/4

Installed:
  python-devel.x86_64 0:2.7.5-86.el7

Dependency Installed:
  python-rpm-macros.noarch 0:3-32.el7    python-srpm-macros.noarch 0:3-32.el7    python2-rpm-macros.noarch 0:3-32.el7

Complete!
```
```
[root@node01 rundeck]# pip install pywinrm[kerberos]
DEPRECATION: Python 2.7 will reach the end of its life on January 1st, 2020. Please upgrade your Python as Python 2.7 won't be maintained after that date. A future version of pip will drop support for Python 2.7. More details about Python 2 support in pip, can be found at https://pip.pypa.io/en/latest/development/release-process/#python-2-support
Requirement already satisfied: pywinrm[kerberos] in /usr/lib/python2.7/site-packages (0.4.1)
Requirement already satisfied: xmltodict in /usr/lib/python2.7/site-packages (from pywinrm[kerberos]) (0.12.0)
Requirement already satisfied: requests>=2.9.1 in /usr/lib/python2.7/site-packages (from pywinrm[kerberos]) (2.22.0)
Requirement already satisfied: requests_ntlm>=0.3.0 in /usr/lib/python2.7/site-packages (from pywinrm[kerberos]) (1.1.0)
Requirement already satisfied: six in /usr/lib/python2.7/site-packages (from pywinrm[kerberos]) (1.13.0)
Collecting pykerberos<2.0.0,>=1.2.1
  Using cached https://files.pythonhosted.org/packages/9a/b8/1ec56b6fa8a2e2a81420bd3d90e70b59fc83f6b857fb2c2c37accddc8be3/pykerberos-1.2.1.tar.gz
Requirement already satisfied: chardet<3.1.0,>=3.0.2 in /usr/lib/python2.7/site-packages (from requests>=2.9.1->pywinrm[kerberos]) (3.0.4)
Requirement already satisfied: idna<2.9,>=2.5 in /usr/lib/python2.7/site-packages (from requests>=2.9.1->pywinrm[kerberos]) (2.8)
Requirement already satisfied: urllib3!=1.25.0,!=1.25.1,<1.26,>=1.21.1 in /usr/lib/python2.7/site-packages (from requests>=2.9.1->pywinrm[kerberos]) (1.25.7)
Requirement already satisfied: certifi>=2017.4.17 in /usr/lib/python2.7/site-packages (from requests>=2.9.1->pywinrm[kerberos]) (2019.11.28)
Requirement already satisfied: ntlm-auth>=1.0.2 in /usr/lib/python2.7/site-packages (from requests_ntlm>=0.3.0->pywinrm[kerberos]) (1.4.0)
Requirement already satisfied: cryptography>=1.3 in /usr/lib64/python2.7/site-packages (from requests_ntlm>=0.3.0->pywinrm[kerberos]) (2.8)
Requirement already satisfied: enum34; python_version < "3" in /usr/lib/python2.7/site-packages (from cryptography>=1.3->requests_ntlm>=0.3.0->pywinrm[kerberos]) (1.1.6)
Requirement already satisfied: cffi!=1.11.3,>=1.8 in /usr/lib64/python2.7/site-packages (from cryptography>=1.3->requests_ntlm>=0.3.0->pywinrm[kerberos]) (1.13.2)
Requirement already satisfied: ipaddress; python_version < "3" in /usr/lib/python2.7/site-packages (from cryptography>=1.3->requests_ntlm>=0.3.0->pywinrm[kerberos]) (1.0.16)
Requirement already satisfied: pycparser in /usr/lib/python2.7/site-packages (from cffi!=1.11.3,>=1.8->cryptography>=1.3->requests_ntlm>=0.3.0->pywinrm[kerberos]) (2.19)
Installing collected packages: pykerberos
    Running setup.py install for pykerberos ... done
Successfully installed pykerberos-1.2.1
WARNING: You are using pip version 19.3.1; however, version 20.0.1 is available.
You should consider upgrading via the 'pip install --upgrade pip' command.
```