### PR TITLE
Added a more specific output from kinit before sending the password

### DIFF
--- a/contents/kerberosauth.py
+++ b/contents/kerberosauth.py
@@ -39,7 +39,7 @@ class KerberosAuth(object):
             self.log.error(msg)
             raise Exception(msg)
 
-        process.expect(".*:")
+        process.expect("Password for .*:")
         process.sendline(self.password)
 
         output = process.read()

--- a/contents/kerberosauth.py
+++ b/contents/kerberosauth.py
@@ -79,7 +79,7 @@ class KerberosAuth(object):
                 self.log.error(msg)
                 return False
 
-            process.expect(".*")
+            process.expect("Password for .*")
             output = process.read()
             process.wait()
             if process.exitstatus != 0:


### PR DESCRIPTION
Expecting anything ending in a colon can send the password to the log when the account is locked.
A user with access to Rundeck and the ability to lock out an account with bad password attempts can use this to learn the password for the py-winrm user, if the account is then unlocked and the password not reset the account has been compromised.