### PR TITLE
FIX: added a function to remove/replace simple quotes when execute CMD command #68

### DIFF
--- a/contents/common.py
+++ b/contents/common.py
@@ -25,3 +25,11 @@ def get_file(destination):
 
     return filename
 
+
+def replace_single_quotes_format(command):
+    command = command + " "
+    command = re.sub(r'\s(\')',' \"', command)
+    command = re.sub(r'(\')\s','\" ', command)
+    command = re.sub(r'\'("\'")\'', "\'", command)
+
+    return command

--- a/contents/winrm-exec.py
+++ b/contents/winrm-exec.py
@@ -10,6 +10,7 @@ import threading
 import logging
 import colored_formatter
 import kerberosauth
+import common
 from colored_formatter import ColoredFormatter
 
 
@@ -157,7 +158,10 @@ if "RD_CONFIG_READTIMEOUT" in os.environ:
 if "RD_CONFIG_OPERATIONTIMEOUT" in os.environ:
     operationtimeout = os.getenv("RD_CONFIG_OPERATIONTIMEOUT")
 
-exec_command = os.getenv("RD_EXEC_COMMAND") 
+exec_command = os.getenv("RD_EXEC_COMMAND")
+
+if "cmd" in shell:
+     exec_command = common.replace_single_quotes_format(exec_command)
 
 endpoint=transport+'://'+args.hostname+':'+port
 


### PR DESCRIPTION
https://github.com/rundeck-plugins/py-winrm-plugin/issues/68

**Is this a bug fix, or an enhancement? Please describe.**
In the project settings section, on the "Node Execution" tab, when the user selects the 'CMD' interpreter and then the user runs a job that executes a command that contains "\" or "'", Rundeck will incorrectly escape them in such a way that CMD cannot run it.

**Describe the solution you've implemented**
In the python script that sends the command via WinRM,  a new function was added that removes/replaces incorrect escaping that were incorrectly added:
 - Removes/replaces single quotes enclosing arguments
  - Inside an argument, removes/replaces double and single quotes that appear around a single quote.  