### PR TITLE
FIX: added new functions to remove or replace the simple quotes

### DIFF
--- a/contents/winrm-exec.py
+++ b/contents/winrm-exec.py
@@ -159,8 +159,8 @@ if "RD_CONFIG_READTIMEOUT" in os.environ:
 if "RD_CONFIG_OPERATIONTIMEOUT" in os.environ:
     operationtimeout = os.getenv("RD_CONFIG_OPERATIONTIMEOUT")
 
-if "RD_CONFIG_CLEANUNNECESSARYESCAPING" in os.environ:
-     if os.getenv("RD_CONFIG_CLEANUNNECESSARYESCAPING") == "true":
+if "RD_CONFIG_CLEANESCAPING" in os.environ:
+     if os.getenv("RD_CONFIG_CLEANESCAPING") == "true":
         cleanescapingflg = True
      else:
         cleanescapingflg = False

--- a/contents/winrm-exec.py
+++ b/contents/winrm-exec.py
@@ -118,6 +118,7 @@ readtimeout = None
 operationtimeout = None
 forcefail = False
 exitBehaviour = "console"
+cleanescapingflg = False
 
 if "RD_CONFIG_AUTHTYPE" in os.environ:
     authentication = os.getenv("RD_CONFIG_AUTHTYPE")
@@ -158,10 +159,18 @@ if "RD_CONFIG_READTIMEOUT" in os.environ:
 if "RD_CONFIG_OPERATIONTIMEOUT" in os.environ:
     operationtimeout = os.getenv("RD_CONFIG_OPERATIONTIMEOUT")
 
-exec_command = os.getenv("RD_EXEC_COMMAND")
+if "RD_CONFIG_CLEANUNNECESSARYESCAPING" in os.environ:
+     if os.getenv("RD_CONFIG_CLEANUNNECESSARYESCAPING") == "true":
+        cleanescapingflg = True
+     else:
+        cleanescapingflg = False
 
-if "cmd" in shell:
-     exec_command = common.replace_single_quotes_format(exec_command)
+exec_command = os.getenv("RD_EXEC_COMMAND")
+log.debug("Command will be executed: " + exec_command)
+
+if cleanescapingflg:
+     exec_command = common.removeSimpleQuotes(exec_command)
+     log.debug("Command escaped will be executed: " + exec_command)
 
 endpoint=transport+'://'+args.hostname+':'+port
 
@@ -214,6 +223,7 @@ log.debug("shell:" + shell)
 log.debug("readtimeout:" + str(readtimeout))
 log.debug("operationtimeout:" + str(operationtimeout))
 log.debug("exit Behaviour:" + exitBehaviour)
+log.debug("cleanescapingflg: " + str(cleanescapingflg))
 log.debug("------------------------------------------")
 
 if not URLLIB_INSTALLED:

--- a/plugin.yaml
+++ b/plugin.yaml
@@ -176,11 +176,9 @@ providers:
       - name: cleanescaping
         title: Clean Escaping
         description: "Cleans unnecessarily Escaped characters on commands"
-        type: Select
-        values: "true, false"
+        type: Boolean
         default: "false"
-        required: true
-        scope: Instance
+        required: false
         renderingOptions:
           groupName: Misc
           instance-scope-node-attribute: "clean-escaping"

--- a/plugin.yaml
+++ b/plugin.yaml
@@ -173,8 +173,8 @@ providers:
         required: false
         renderingOptions:
           groupName: Kerberos
-      - name: cleanunnecessaryescaping
-        title: Clean Unnecessary Escaping
+      - name: cleanescaping
+        title: Clean Escaping
         description: "Cleans unnecessarily Escaped characters on commands"
         type: Select
         values: "true, false"
@@ -183,7 +183,7 @@ providers:
         scope: Instance
         renderingOptions:
           groupName: Misc
-          instance-scope-node-attribute: "clean-unnecessary-escaping"
+          instance-scope-node-attribute: "clean-escaping"
   - name: WinRMcpPython
     title: WinRM Python File Copier
     description: Copying files to remote Windows computer

--- a/plugin.yaml
+++ b/plugin.yaml
@@ -173,6 +173,17 @@ providers:
         required: false
         renderingOptions:
           groupName: Kerberos
+      - name: cleanunnecessaryescaping
+        title: Clean Unnecessary Escaping
+        description: "Cleans unnecessarily Escaped characters on commands"
+        type: Select
+        values: "true, false"
+        default: "false"
+        required: true
+        scope: Instance
+        renderingOptions:
+          groupName: Misc
+          instance-scope-node-attribute: "clean-unnecessary-escaping"
   - name: WinRMcpPython
     title: WinRM Python File Copier
     description: Copying files to remote Windows computer


### PR DESCRIPTION
https://github.com/rundeck-plugins/py-winrm-plugin/issues/70

**Is this a bug fix, or an enhancement? Please describe.**
In the project settings section, on the "Node Execution" tab, when the user selects the 'CMD' interpreter and then the user runs a job that executes a command that contains "\", "'" or adds options, Rundeck will incorrectly escape them in such a way that CMD cannot run it.

**Describe the solution you've implemented**
In the python script that sends the command via WinRM,  a new function was added that removes or replaces incorrect escaping that were incorrectly added:
 - Adds a flag that when, is activated, fixes incorrect command escaping 
 - Search the absolute path and try to replace the simple quotes to double quotes
 - Removes single quotes or replace simple quotes to double quotes enclosing arguments