### PR TITLE
RUN-506: Appending files instead of overriding

### DIFF
--- a/contents/winrm-filecopier.py
+++ b/contents/winrm-filecopier.py
@@ -187,7 +187,7 @@ class CopyFiles(object):
         self.session.run_ps('if (!(Test-Path {0})) {{ New-Item -ItemType directory -Path {0} }}'.format(remote_path))
 
         if(override):
-            self.session.run_ps('if ((Test-Path {0})) {{ rm {0} }}'.format(full_path))
+            self.session.run_ps('if ((Test-Path {0} -PathType Leaf)) {{ rm {0} }}'.format(full_path))
 
         size = os.stat(local_path).st_size
         with open(local_path, 'rb') as f:

--- a/contents/winrm-filecopier.py
+++ b/contents/winrm-filecopier.py
@@ -174,7 +174,8 @@ class CopyFiles(object):
                     remote_filename,
                     local_path,
                     step=2048,
-                    quiet=True):
+                    quiet=True,
+                    override=False):
 
         if remote_path.endswith('/') or remote_path.endswith('\\'):
             full_path = remote_path + remote_filename
@@ -184,6 +185,9 @@ class CopyFiles(object):
         print("coping file %s to %s" % (local_path, full_path))
 
         self.session.run_ps('if (!(Test-Path {0})) {{ New-Item -ItemType directory -Path {0} }}'.format(remote_path))
+        
+        if(override):
+            self.session.run_ps('if ((Test-Path {0})) {{ rm {0} }}'.format(full_path))
 
         size = os.stat(local_path).st_size
         with open(local_path, 'rb') as f:
@@ -245,6 +249,10 @@ kinit = None
 krb5config = None
 krbdelegation = False
 forceTicket = False
+override=False
+
+if os.environ.get('RD_CONFIG_OVERRIDE') == 'true':
+    override = True
 
 if "RD_CONFIG_AUTHTYPE" in os.environ:
     authentication = os.getenv("RD_CONFIG_AUTHTYPE")
@@ -377,7 +385,8 @@ if not os.path.isdir(args.source):
     copy.winrm_upload(remote_path=destination,
                       remote_filename=filename,
                       local_path=args.source,
-                      quiet=quiet)
+                      quiet=quiet,
+                      override=override)
 else:
     log.warn("The source is a directory, skipping copy")
 

--- a/plugin.yaml
+++ b/plugin.yaml
@@ -284,6 +284,10 @@ providers:
         name: debug
         title: Debug?
         description: 'Write debug messages'
+      - type: Boolean
+        name: override
+        title: Override?
+        description: 'Overrides the file on the remote server if it already exists'
       - name: krb5config
         title: krb5 Config File
         description: "Path of krb5.conf file"
@@ -410,4 +414,3 @@ providers:
         required: false
         renderingOptions:
           groupName: Kerberos
-


### PR DESCRIPTION
Fixes: https://github.com/rundeckpro/rundeckpro/issues/2147

winrm-filecopier.py now deletes the target file if it already exists on the remote server on user's behalf.

![image](https://user-images.githubusercontent.com/49494423/142025354-8f838225-423b-40f9-9841-493837b8afa6.png)