### PR TITLE
RUN-1290: Interpreter select + update build

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -6,55 +6,47 @@ buildscript {
         mavenCentral()
     }
 }
+
 plugins {
-    id 'pl.allegro.tech.build.axion-release' version '1.9.3'
+    id 'pl.allegro.tech.build.axion-release' version '1.13.6'
 }
 
+apply plugin: 'groovy'
 apply plugin: 'maven-publish'
 
 defaultTasks 'clean', 'build', 'pluginZip'
-task build(dependsOn: ['pluginZip']) doLast {
+
+scmVersion {
+    ignoreUncommittedChanges = true
+    tag {
+        prefix = 'v'
+        versionSeparator = ''
+    }
+}
+
+project.version = scmVersion.version
+
+def pluginName = 'Python Winrm Node Executor/File Copier Plugin'
+def pluginDescription = "Connect to remote windows nodes using WINRM"
+def sopsCopyright = "© 2022, Pagerduty, Inc."
+def sopsUrl = "https://pagerduty.com"
+def buildDateString=new Date().format("yyyy-MM-dd'T'HH:mm:ssX")
+def archivesBaseName = "py-winrm-plugin"
+def pluginBaseFolder = "."
+def archiveFilename = archivesBaseName + '-' + version
+
+build.dependsOn('pluginZip')
+
+clean {
+    delete('build')
 }
 
 task install(dependsOn: ['build','publishToMavenLocal']) doLast {
 }
 
-task clean(type: Delete) {
-    delete('build')
-}
-
-ext.pluginName = 'Python Winrm Node Executor/File Copier Plugin'
-ext.pluginDescription = "Connect to remote windows nodes using WINRM"
-ext.sopsCopyright = "© 2022, Pagerduty, Inc."
-ext.sopsUrl = "https://pagerduty.com"
-ext.buildDateString=new Date().format("yyyy-MM-dd'T'HH:mm:ssX")
-ext.archivesBaseName = "py-winrm-plugin"
-ext.pluginBaseFolder = "."
-
-project.version = scmVersion.version
-ext.archiveFilename = ext.archivesBaseName + '-' + version
-
-scmVersion {
-    ignoreUncommittedChanges = true
-    tag {
-        prefix = ''
-        versionSeparator = ''
-        def origDeserialize=deserialize
-        //apend .0 to satisfy semver if the tag version is only X.Y
-        deserialize = { config, position, tagName ->
-            def orig = origDeserialize(config, position, tagName)
-            if (orig.split('\\.').length < 3) {
-                orig += ".0"
-            }
-            orig
-        }
-    }
-}
-
-
 task pluginZip(type: Jar) {
     destinationDir = file("build/libs")
-    baseName = project.ext.archivesBaseName
+    baseName = project.archivesBaseName
     version = project.version
     classifier = ''
     extension = 'zip'

--- a/build.gradle
+++ b/build.gradle
@@ -1,110 +1,39 @@
-import org.apache.tools.ant.filters.ReplaceTokens
-
 buildscript {
     repositories {
-        mavenLocal()
         mavenCentral()
     }
 }
-
 plugins {
-    id 'pl.allegro.tech.build.axion-release' version '1.13.6'
+    id 'pl.allegro.tech.build.axion-release' version '1.13.4'
 }
-
-apply plugin: 'groovy'
-apply plugin: 'maven-publish'
-
-defaultTasks 'clean', 'build', 'pluginZip'
 
 scmVersion {
     ignoreUncommittedChanges = true
     tag {
-        prefix = 'v'
+        prefix = ''
         versionSeparator = ''
+        def origDeserialize=deserialize
+        //apend .0 to satisfy semver if the tag version is only X.Y
+        deserialize = { config, position, tagName ->
+            def orig = origDeserialize(config, position, tagName)
+            if (orig.split('\\.').length < 3) {
+                orig += ".0"
+            }
+            orig
+        }
     }
 }
+
+ext.pluginName = 'Python Winrm Node Executor/File Copier Plugin'
+ext.pluginDescription = "Connect to remote windows nodes using WINRM"
+ext.sopsCopyright = "© 2022, Pagerduty, Inc."
+ext.sopsUrl = "https://pagerduty.com"
+ext.buildDateString=new Date().format("yyyy-MM-dd'T'HH:mm:ssX")
+ext.archivesBaseName = "py-winrm-plugin"
+ext.pluginBaseFolder = "."
 
 project.version = scmVersion.version
 
-def pluginName = 'Python Winrm Node Executor/File Copier Plugin'
-def pluginDescription = "Connect to remote windows nodes using WINRM"
-def sopsCopyright = "© 2022, Pagerduty, Inc."
-def sopsUrl = "https://pagerduty.com"
-def buildDateString=new Date().format("yyyy-MM-dd'T'HH:mm:ssX")
-def archivesBaseName = "py-winrm-plugin"
-def pluginBaseFolder = "."
-def archiveFilename = archivesBaseName + '-' + version
+ext.archiveFilename = ext.archivesBaseName + '-' + version 
 
-build.dependsOn('pluginZip')
-
-clean {
-    delete('build')
-}
-
-task install(dependsOn: ['build','publishToMavenLocal']) doLast {
-}
-
-task pluginZip(type: Jar) {
-    destinationDir = file("build/libs")
-    baseName = project.archivesBaseName
-    version = project.version
-    classifier = ''
-    extension = 'zip'
-
-    from("${project.buildDir}/zip-contents") {
-        include("*.yaml")
-        include("resources/**")
-        include("contents/*")
-        into(archiveFilename)
-    }
-
-    manifest {
-        attributes 'Rundeck-Plugin-Name': pluginName.toString(),
-            'Rundeck-Plugin-Description': pluginDescription.toString(),
-            'Rundeck-Plugin-Archive': 'true',
-            'Rundeck-Plugin-File-Version': version,
-            'Rundeck-Plugin-Author': sopsCopyright,
-            'Rundeck-Plugin-URL': sopsUrl,
-            'Rundeck-Plugin-Date': buildDateString
-    }
-}
-
-pluginZip.doFirst {
-    def assetsMap = new Properties()
-    def tokens = assetsMap + [
-        version    : version,
-        date       : new Date().format("yyyy-MM-dd'T'HH:mm:ssX").toString(),
-        author     : sopsCopyright,
-        url        : sopsUrl,
-        title      : pluginName,
-        description: pluginDescription,
-        name       : archivesBaseName.toString(),
-    ]
-
-    copy {
-
-        from("${project.projectDir}/resources"){
-            include '**/*'
-            into "resources"
-        }
-
-        from("${project.projectDir}/contents"){
-            into "contents"
-        }
-
-        from("${project.projectDir}/plugin.yaml") {
-            filter(ReplaceTokens, tokens: tokens)
-            exclude '**/*.png'
-        }
-
-        into "${project.buildDir}/zip-contents"
-    }
-}
-
-publishing {
-    publications {
-        mavenZip(MavenPublication) {
-            artifact pluginZip
-        }
-    }
-}
+apply from: 'https://raw.githubusercontent.com/rundeck-plugins/build-zip/gradle-5.6/build.gradle'

--- a/build.gradle
+++ b/build.gradle
@@ -1,5 +1,8 @@
+import org.apache.tools.ant.filters.ReplaceTokens
+
 buildscript {
     repositories {
+        mavenLocal()
         mavenCentral()
     }
 }
@@ -7,14 +10,29 @@ plugins {
     id 'pl.allegro.tech.build.axion-release' version '1.9.3'
 }
 
+apply plugin: 'maven-publish'
+
+defaultTasks 'clean', 'build', 'pluginZip'
+task build(dependsOn: ['pluginZip']) doLast {
+}
+
+task install(dependsOn: ['build','publishToMavenLocal']) doLast {
+}
+
+task clean(type: Delete) {
+    delete('build')
+}
+
 ext.pluginName = 'Python Winrm Node Executor/File Copier Plugin'
 ext.pluginDescription = "Connect to remote windows nodes using WINRM"
-ext.sopsCopyright = "© 2017, Rundeck, Inc."
-ext.sopsUrl = "http://rundeck.com"
+ext.sopsCopyright = "© 2022, Pagerduty, Inc."
+ext.sopsUrl = "https://pagerduty.com"
 ext.buildDateString=new Date().format("yyyy-MM-dd'T'HH:mm:ssX")
 ext.archivesBaseName = "py-winrm-plugin"
 ext.pluginBaseFolder = "."
 
+project.version = scmVersion.version
+ext.archiveFilename = ext.archivesBaseName + '-' + version
 
 scmVersion {
     ignoreUncommittedChanges = true
@@ -33,8 +51,68 @@ scmVersion {
     }
 }
 
-project.version = scmVersion.version
 
-ext.archiveFilename = ext.archivesBaseName + '-' + version 
+task pluginZip(type: Jar) {
+    destinationDir = file("build/libs")
+    baseName = project.ext.archivesBaseName
+    version = project.version
+    classifier = ''
+    extension = 'zip'
 
-apply from: 'https://raw.githubusercontent.com/rundeck-plugins/build-zip/master/build.gradle'
+    from("${project.buildDir}/zip-contents") {
+        include("*.yaml")
+        include("resources/**")
+        include("contents/*")
+        into(archiveFilename)
+    }
+
+    manifest {
+        attributes 'Rundeck-Plugin-Name': pluginName.toString(),
+            'Rundeck-Plugin-Description': pluginDescription.toString(),
+            'Rundeck-Plugin-Archive': 'true',
+            'Rundeck-Plugin-File-Version': version,
+            'Rundeck-Plugin-Author': sopsCopyright,
+            'Rundeck-Plugin-URL': sopsUrl,
+            'Rundeck-Plugin-Date': buildDateString
+    }
+}
+
+pluginZip.doFirst {
+    def assetsMap = new Properties()
+    def tokens = assetsMap + [
+        version    : version,
+        date       : new Date().format("yyyy-MM-dd'T'HH:mm:ssX").toString(),
+        author     : sopsCopyright,
+        url        : sopsUrl,
+        title      : pluginName,
+        description: pluginDescription,
+        name       : archivesBaseName.toString(),
+    ]
+
+    copy {
+
+        from("${project.projectDir}/resources"){
+            include '**/*'
+            into "resources"
+        }
+
+        from("${project.projectDir}/contents"){
+            into "contents"
+        }
+
+        from("${project.projectDir}/plugin.yaml") {
+            filter(ReplaceTokens, tokens: tokens)
+            exclude '**/*.png'
+        }
+
+        into "${project.buildDir}/zip-contents"
+    }
+}
+
+publishing {
+    publications {
+        mavenZip(MavenPublication) {
+            artifact pluginZip
+        }
+    }
+}

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-3.5-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.4.2-all.zip

--- a/plugin.yaml
+++ b/plugin.yaml
@@ -25,7 +25,8 @@ providers:
       - name: interpreter
         title: Python Interpreter
         description: "Python Interpreter (Default: python)"
-        type: String
+        type: Select
+        values: "python,python2,python3"
         default: "python"
         required: true
         scope: Instance
@@ -194,7 +195,8 @@ providers:
       - name: interpreter
         title: Python Interpreter
         description: "Python Interpreter (Default: python)"
-        type: String
+        type: Select
+        values: "python,python2,python3"
         default: "python"
         required: true
         scope: Instance
@@ -324,7 +326,8 @@ providers:
       - name: interpreter
         title: Python Interpreter
         description: "Python Interpreter (Default: python)"
-        type: String
+        type: Select
+        values: "python,python2,python3"
         default: "python"
         required: true
         scope: Instance


### PR DESCRIPTION
This PR removes the ability to freely input the name of your python interpreter, for security reasons. It also updates Gradle to 7.4.2, and removes reliance on the rundeck-plugins/build-zip build gradle by pulling that configuration in locally.