### PR TITLE
py-winrm-plugin dependency auto install (except kerberos)

### DIFF
--- a/contents/winrm-check.py
+++ b/contents/winrm-check.py
@@ -25,114 +25,119 @@ if ISPY3:
 else:
     from inspect import getargspec
 
+## import pip module
+import pip
+
+## check urllib3
 try:
     import requests.packages.urllib3
     requests.packages.urllib3.disable_warnings()
     URLLIB_INSTALLED = True
 except ImportError as e:
-    try:
-        import pip
-        package='urllib3'
-        pip.main(['install',package])
+    package='urllib3'
+    pip.main(['install',package])
+    URLLIB_INSTALLED = False
+try:
+    import requests.packages.urllib3
+    requests.packages.urllib3.disable_warnings()
+    URLLIB_INSTALLED = True
+except ImportError as e:
+    URLLIB_INSTALLED = False
 
-        import requests.packages.urllib3
-        requests.packages.urllib3.disable_warnings()
-        URLLIB_INSTALLED = True
-    except ImportError as e:
-        URLLIB_INSTALLED = False
-
+## check pywinrm
 try:
     import winrm
     WINRM_INSTALLED = True
 except ImportError as e:
-    try:
-        import pip
-        package='pywinrm'
-        pip.main(['install',package])
-        
-        import winrm
-        WINRM_INSTALLED = True
-    except ImportError as e:
-        WINRM_INSTALLED = False
+    package='pywinrm'
+    pip.main(['install',package])
+    WINRM_INSTALLED = False
+ try:       
+    import winrm
+    WINRM_INSTALLED = True
+except ImportError as e:
+    WINRM_INSTALLED = False
 
+## check requests
 try:
     import requests
     REQUESTS_INSTALLED = True
 except ImportError as e:
-    try:
-        import pip
-        package='requests'
-        pip.main(['install',package])
-        
-        import requests
-        REQUESTS_INSTALLED = True
-    except ImportError as e:
-        REQUESTS_INSTALLED = False
+    package='requests'
+    pip.main(['install',package])
+    REQUESTS_INSTALLED = False
+try:    
+    import requests
+    REQUESTS_INSTALLED = True
+except ImportError as e:
+    REQUESTS_INSTALLED = False
 
+## check kerberos
 try:
     from requests_kerberos import HTTPKerberosAuth, REQUIRED, OPTIONAL, DISABLED
     KRB_INSTALLED = True
 except ImportError:
     KRB_INSTALLED = False
 
+## check requests ntlm
 try:
     from requests_ntlm import HttpNtlmAuth
     HAS_NTLM = True
 except ImportError as e:
-    try:
-        import pip
-        package='requests-ntlm'
-        pip.main(['install',package])
+    package='requests-ntlm'
+    pip.main(['install',package])
+    HAS_NTLM = False
+try:
+    from requests_ntlm import HttpNtlmAuth
+    HAS_NTLM = True
+except ImportError as e:
+    HAS_NTLM = False
 
-        from requests_ntlm import HttpNtlmAuth
-        HAS_NTLM = True
-    except ImportError as e:
-        HAS_NTLM = False
-
+## check requests credssp
 try:
     from requests_credssp import HttpCredSSPAuth
     HAS_CREDSSP = True
 except ImportError as e:
-    try:
-        import pip
-        package='requests-credssp'
-        pip.main(['install',package])
-        package='pywinrm[credssp]'
-        pip.main(['install',package])
+    package='requests-credssp'
+    pip.main(['install',package])
+    package='pywinrm[credssp]'
+    pip.main(['install',package])
+    HAS_CREDSSP = False
+try:
+    from requests_credssp import HttpCredSSPAuth
+    HAS_CREDSSP = True
+except ImportError as e:
+    HAS_CREDSSP = False
 
-        from requests_credssp import HttpCredSSPAuth
-        HAS_CREDSSP = True
-    except ImportError as e:
-        HAS_CREDSSP = False
-
+## check pexpect
 try:
     import pexpect
-
     if hasattr(pexpect, 'spawn'):
         argspec = getargspec(pexpect.spawn.__init__)
         if 'echo' in argspec.args:
             HAS_PEXPECT = True
 except ImportError as e:
-    try:
-        import pip
         package='pexpect'
         pip.main(['install',package])
-
-        import pexpect
-
-        if hasattr(pexpect, 'spawn'):
-            argspec = getargspec(pexpect.spawn.__init__)
-            if 'echo' in argspec.args:
-                HAS_PEXPECT = True
-    except ImportError as e:
         HAS_PEXPECT = False
+try:
+    import pexpect
+    if hasattr(pexpect, 'spawn'):
+        argspec = getargspec(pexpect.spawn.__init__)
+        if 'echo' in argspec.args:
+            HAS_PEXPECT = True
+except ImportError as e:
+    HAS_PEXPECT = False
 
+## remove pip module
+del pip
+
+## log level
 log_level = 'INFO'
 if os.environ.get('RD_JOB_LOGLEVEL') == 'DEBUG':
     log_level = 'DEBUG'
 else:
     log_level = 'ERROR'
-
 ##end
 
 console = logging.StreamHandler()

--- a/contents/winrm-check.py
+++ b/contents/winrm-check.py
@@ -52,7 +52,7 @@ except ImportError as e:
     package='pywinrm'
     pip.main(['install',package])
     WINRM_INSTALLED = False
- try:       
+try:   
     import winrm
     WINRM_INSTALLED = True
 except ImportError as e:
@@ -66,7 +66,7 @@ except ImportError as e:
     package='requests'
     pip.main(['install',package])
     REQUESTS_INSTALLED = False
-try:    
+try:
     import requests
     REQUESTS_INSTALLED = True
 except ImportError as e:

--- a/contents/winrm-check.py
+++ b/contents/winrm-check.py
@@ -49,12 +49,6 @@ except ImportError as e:
         import pip
         package='pywinrm'
         pip.main(['install',package])
-        package='pywinrm[credssp]'
-        pip.main(['install',package])
-        package='pywinrm[kerberos]'
-        pip.main(['install',package])
-        package='pywinrm[ntlm]'
-        pip.main(['install',package])
         
         import winrm
         WINRM_INSTALLED = True
@@ -78,21 +72,23 @@ except ImportError as e:
 try:
     from requests_kerberos import HTTPKerberosAuth, REQUIRED, OPTIONAL, DISABLED
     KRB_INSTALLED = True
-except ImportError:
+except ImportError as e:
     try:
         import pip
         package='requests-kerberos'
         pip.main(['install',package])
+        package='pywinrm[kerberos]'
+        pip.main(['install',package])
 
         from requests_kerberos import HTTPKerberosAuth, REQUIRED, OPTIONAL, DISABLED
         KRB_INSTALLED = True
-    except ImportError:
+    except ImportError as e:
         KRB_INSTALLED = False
 
 try:
     from requests_ntlm import HttpNtlmAuth
     HAS_NTLM = True
-except ImportError as ie:
+except ImportError as e:
     try:
         import pip
         package='requests-ntlm'
@@ -100,21 +96,23 @@ except ImportError as ie:
 
         from requests_ntlm import HttpNtlmAuth
         HAS_NTLM = True
-    except ImportError as ie:
+    except ImportError as e:
         HAS_NTLM = False
 
 try:
     from requests_credssp import HttpCredSSPAuth
     HAS_CREDSSP = True
-except ImportError as ie:
+except ImportError as e:
     try:
         import pip
         package='requests-credssp'
         pip.main(['install',package])
+        package='pywinrm[credssp]'
+        pip.main(['install',package])
 
         from requests_credssp import HttpCredSSPAuth
         HAS_CREDSSP = True
-    except ImportError as ie:
+    except ImportError as e:
         HAS_CREDSSP = False
 
 try:

--- a/contents/winrm-check.py
+++ b/contents/winrm-check.py
@@ -78,11 +78,12 @@ except ImportError as e:
     pip.main(['install',package])
     package='pywinrm[kerberos]'
     pip.main(['install',package])
-    try:
-        from requests_kerberos import HTTPKerberosAuth, REQUIRED, OPTIONAL, DISABLED
-        KRB_INSTALLED = True
-    except ImportError as e:
-        KRB_INSTALLED = False
+
+try:
+    from requests_kerberos import HTTPKerberosAuth, REQUIRED, OPTIONAL, DISABLED
+    KRB_INSTALLED = True
+except ImportError as e:
+    KRB_INSTALLED = False
 
 try:
     from requests_ntlm import HttpNtlmAuth

--- a/contents/winrm-check.py
+++ b/contents/winrm-check.py
@@ -72,7 +72,7 @@ except ImportError as e:
 try:
     from requests_kerberos import HTTPKerberosAuth, REQUIRED, OPTIONAL, DISABLED
     KRB_INSTALLED = True
-except ImportError as e:
+except ImportError:
     import pip
     package='requests-kerberos'
     pip.main(['install',package])
@@ -82,7 +82,7 @@ except ImportError as e:
 try:
     from requests_kerberos import HTTPKerberosAuth, REQUIRED, OPTIONAL, DISABLED
     KRB_INSTALLED = True
-except ImportError as e:
+except ImportError:
     KRB_INSTALLED = False
 
 try:

--- a/contents/winrm-check.py
+++ b/contents/winrm-check.py
@@ -47,8 +47,6 @@ try:
 except ImportError as e:
     try:
         import pip
-        package='winrm'
-        pip.main(['install',package])
         package='pywinrm'
         pip.main(['install',package])
         
@@ -75,13 +73,12 @@ try:
     from requests_kerberos import HTTPKerberosAuth, REQUIRED, OPTIONAL, DISABLED
     KRB_INSTALLED = True
 except ImportError as e:
+    import pip
+    package='requests-kerberos'
+    pip.main(['install',package])
+    package='pywinrm[kerberos]'
+    pip.main(['install',package])
     try:
-        import pip
-        package='requests-kerberos'
-        pip.main(['install',package])
-        package='pywinrm[kerberos]'
-        pip.main(['install',package])
-
         from requests_kerberos import HTTPKerberosAuth, REQUIRED, OPTIONAL, DISABLED
         KRB_INSTALLED = True
     except ImportError as e:

--- a/contents/winrm-check.py
+++ b/contents/winrm-check.py
@@ -10,7 +10,6 @@ import colored_formatter
 from colored_formatter import ColoredFormatter
 import kerberosauth
 
-
 #checking and importing dependencies
 ISPY3 = sys.version_info[0] == 3
 WINRM_INSTALLED = False
@@ -19,6 +18,7 @@ KRB_INSTALLED = False
 HAS_NTLM = False
 HAS_CREDSSP = False
 HAS_PEXPECT = False
+REQUESTS_INSTALLED = False
 
 if ISPY3:
     from inspect import getfullargspec as getargspec
@@ -30,35 +30,92 @@ try:
     requests.packages.urllib3.disable_warnings()
     URLLIB_INSTALLED = True
 except ImportError as e:
-    URLLIB_INSTALLED = False
+    try:
+        import pip
+        package='urllib3'
+        pip.main(['install',package])
+
+        import requests.packages.urllib3
+        requests.packages.urllib3.disable_warnings()
+        URLLIB_INSTALLED = True
+    except ImportError as e:
+        URLLIB_INSTALLED = False
 
 try:
     import winrm
-
     WINRM_INSTALLED = True
 except ImportError as e:
-    WINRM_INSTALLED = False
+    try:
+        import pip
+        package='pywinrm'
+        pip.main(['install',package])
+        package='pywinrm[credssp]'
+        pip.main(['install',package])
+        package='pywinrm[kerberos]'
+        pip.main(['install',package])
+        package='pywinrm[ntlm]'
+        pip.main(['install',package])
+        
+        import winrm
+        WINRM_INSTALLED = True
+    except ImportError as e:
+        WINRM_INSTALLED = False
+
+try:
+    import requests
+    REQUESTS_INSTALLED = True
+except ImportError as e:
+    try:
+        import pip
+        package='requests'
+        pip.main(['install',package])
+        
+        import requests
+        REQUESTS_INSTALLED = True
+    except ImportError as e:
+        REQUESTS_INSTALLED = False
 
 try:
     from requests_kerberos import HTTPKerberosAuth, REQUIRED, OPTIONAL, DISABLED
-
     KRB_INSTALLED = True
 except ImportError:
-    KRB_INSTALLED = False
+    try:
+        import pip
+        package='requests-kerberos'
+        pip.main(['install',package])
+
+        from requests_kerberos import HTTPKerberosAuth, REQUIRED, OPTIONAL, DISABLED
+        KRB_INSTALLED = True
+    except ImportError:
+        KRB_INSTALLED = False
 
 try:
     from requests_ntlm import HttpNtlmAuth
-
     HAS_NTLM = True
 except ImportError as ie:
-    HAS_NTLM = False
+    try:
+        import pip
+        package='requests-ntlm'
+        pip.main(['install',package])
+
+        from requests_ntlm import HttpNtlmAuth
+        HAS_NTLM = True
+    except ImportError as ie:
+        HAS_NTLM = False
 
 try:
     from requests_credssp import HttpCredSSPAuth
-
     HAS_CREDSSP = True
 except ImportError as ie:
-    HAS_CREDSSP = False
+    try:
+        import pip
+        package='requests-credssp'
+        pip.main(['install',package])
+
+        from requests_credssp import HttpCredSSPAuth
+        HAS_CREDSSP = True
+    except ImportError as ie:
+        HAS_CREDSSP = False
 
 try:
     import pexpect
@@ -68,7 +125,19 @@ try:
         if 'echo' in argspec.args:
             HAS_PEXPECT = True
 except ImportError as e:
-    HAS_PEXPECT = False
+    try:
+        import pip
+        package='pexpect'
+        pip.main(['install',package])
+
+        import pexpect
+
+        if hasattr(pexpect, 'spawn'):
+            argspec = getargspec(pexpect.spawn.__init__)
+            if 'echo' in argspec.args:
+                HAS_PEXPECT = True
+    except ImportError as e:
+        HAS_PEXPECT = False
 
 log_level = 'INFO'
 if os.environ.get('RD_JOB_LOGLEVEL') == 'DEBUG':
@@ -77,13 +146,6 @@ else:
     log_level = 'ERROR'
 
 ##end
-
-
-log_level = 'INFO'
-if os.environ.get('RD_JOB_LOGLEVEL') == 'DEBUG':
-    log_level = 'DEBUG'
-else:
-    log_level = 'ERROR'
 
 console = logging.StreamHandler()
 console.setFormatter(ColoredFormatter(colored_formatter.format()))
@@ -206,29 +268,32 @@ if(certpath):
     log.debug("certpath:" + certpath)
 log.debug("------------------------------------------")
 
+if not REQUESTS_INSTALLED:
+    log.error("requests is not installed, try: python -m pip install requests")
+    sys.exit(1)
 
 if not URLLIB_INSTALLED:
-    log.error("request and urllib3 not installed, try: pip install requests &&  pip install urllib3")
+    log.error("urllib3 is not installed, try: python -m pip install urllib3")
     sys.exit(1)
 
 if not WINRM_INSTALLED:
-    log.error("winrm not installed, try: pip install pywinrm")
+    log.error("winrm is not installed, try: python -m pip install pywinrm")
     sys.exit(1)
 
 if authentication == "kerberos" and not KRB_INSTALLED:
-    log.error("Kerberos not installed, try: pip install requests-kerberos")
+    log.error("Kerberos is not installed, try: python -m pip install pywinrm[kerberos]")
     sys.exit(1)
 
 if authentication == "kerberos" and not HAS_PEXPECT:
-    log.error("pexpect not installed, try: pip install pexpect")
+    log.error("pexpect is not installed, try: python -m pip install pexpect")
     sys.exit(1)
 
 if authentication == "credssp" and not HAS_CREDSSP:
-    log.error("CredSSP not installed, try: pip install pywinrm[credssp]")
+    log.error("CredSSP is not installed, try: python -m pip install pywinrm[credssp]")
     sys.exit(1)
 
 if authentication == "ntlm" and not HAS_NTLM:
-    log.error("NTLM not installed, try: pip install requests_ntlm")
+    log.error("NTLM is not installed, try: python -m pip install requests_ntlm")
     sys.exit(1)
 
 arguments={}

--- a/contents/winrm-check.py
+++ b/contents/winrm-check.py
@@ -73,16 +73,6 @@ try:
     from requests_kerberos import HTTPKerberosAuth, REQUIRED, OPTIONAL, DISABLED
     KRB_INSTALLED = True
 except ImportError:
-    import pip
-    package='requests-kerberos'
-    pip.main(['install',package])
-    package='pywinrm[kerberos]'
-    pip.main(['install',package])
-
-try:
-    from requests_kerberos import HTTPKerberosAuth, REQUIRED, OPTIONAL, DISABLED
-    KRB_INSTALLED = True
-except ImportError:
     KRB_INSTALLED = False
 
 try:

--- a/contents/winrm-check.py
+++ b/contents/winrm-check.py
@@ -47,6 +47,8 @@ try:
 except ImportError as e:
     try:
         import pip
+        package='winrm'
+        pip.main(['install',package])
         package='pywinrm'
         pip.main(['install',package])
         

--- a/contents/winrm-exec.py
+++ b/contents/winrm-exec.py
@@ -59,7 +59,7 @@ except ImportError as e:
     package='pywinrm'
     pip.main(['install',package])
     WINRM_INSTALLED = False
- try:       
+try:
     import winrm
     WINRM_INSTALLED = True
 except ImportError as e:
@@ -73,7 +73,7 @@ except ImportError as e:
     package='requests'
     pip.main(['install',package])
     REQUESTS_INSTALLED = False
-try:    
+try:
     import requests
     REQUESTS_INSTALLED = True
 except ImportError as e:

--- a/contents/winrm-exec.py
+++ b/contents/winrm-exec.py
@@ -60,6 +60,8 @@ try:
 except ImportError as e:
     try:
         import pip
+        package='winrm'
+        pip.main(['install',package])
         package='pywinrm'
         pip.main(['install',package])
         

--- a/contents/winrm-exec.py
+++ b/contents/winrm-exec.py
@@ -31,6 +31,7 @@ KRB_INSTALLED = False
 HAS_NTLM = False
 HAS_CREDSSP = False
 HAS_PEXPECT = False
+REQUESTS_INSTALLED = False
 
 if ISPY3:
     from inspect import getfullargspec as getargspec
@@ -42,35 +43,92 @@ try:
     requests.packages.urllib3.disable_warnings()
     URLLIB_INSTALLED = True
 except ImportError as e:
-    URLLIB_INSTALLED = False
+    try:
+        import pip
+        package='urllib3'
+        pip.main(['install',package])
+
+        import requests.packages.urllib3
+        requests.packages.urllib3.disable_warnings()
+        URLLIB_INSTALLED = True
+    except ImportError as e:
+        URLLIB_INSTALLED = False
 
 try:
     import winrm
-
     WINRM_INSTALLED = True
 except ImportError as e:
-    WINRM_INSTALLED = False
+    try:
+        import pip
+        package='pywinrm'
+        pip.main(['install',package])
+        package='pywinrm[credssp]'
+        pip.main(['install',package])
+        package='pywinrm[kerberos]'
+        pip.main(['install',package])
+        package='pywinrm[ntlm]'
+        pip.main(['install',package])
+        
+        import winrm
+        WINRM_INSTALLED = True
+    except ImportError as e:
+        WINRM_INSTALLED = False
+
+try:
+    import requests
+    REQUESTS_INSTALLED = True
+except ImportError as e:
+    try:
+        import pip
+        package='requests'
+        pip.main(['install',package])
+        
+        import requests
+        REQUESTS_INSTALLED = True
+    except ImportError as e:
+        REQUESTS_INSTALLED = False
 
 try:
     from requests_kerberos import HTTPKerberosAuth, REQUIRED, OPTIONAL, DISABLED
-
     KRB_INSTALLED = True
 except ImportError:
-    KRB_INSTALLED = False
+    try:
+        import pip
+        package='requests-kerberos'
+        pip.main(['install',package])
+
+        from requests_kerberos import HTTPKerberosAuth, REQUIRED, OPTIONAL, DISABLED
+        KRB_INSTALLED = True
+    except ImportError:
+        KRB_INSTALLED = False
 
 try:
     from requests_ntlm import HttpNtlmAuth
-
     HAS_NTLM = True
 except ImportError as ie:
-    HAS_NTLM = False
+    try:
+        import pip
+        package='requests-ntlm'
+        pip.main(['install',package])
+
+        from requests_ntlm import HttpNtlmAuth
+        HAS_NTLM = True
+    except ImportError as ie:
+        HAS_NTLM = False
 
 try:
     from requests_credssp import HttpCredSSPAuth
-
     HAS_CREDSSP = True
 except ImportError as ie:
-    HAS_CREDSSP = False
+    try:
+        import pip
+        package='requests-credssp'
+        pip.main(['install',package])
+
+        from requests_credssp import HttpCredSSPAuth
+        HAS_CREDSSP = True
+    except ImportError as ie:
+        HAS_CREDSSP = False
 
 try:
     import pexpect
@@ -80,12 +138,25 @@ try:
         if 'echo' in argspec.args:
             HAS_PEXPECT = True
 except ImportError as e:
-    HAS_PEXPECT = False
+    try:
+        import pip
+        package='pexpect'
+        pip.main(['install',package])
 
+        import pexpect
+
+        if hasattr(pexpect, 'spawn'):
+            argspec = getargspec(pexpect.spawn.__init__)
+            if 'echo' in argspec.args:
+                HAS_PEXPECT = True
+    except ImportError as e:
+        HAS_PEXPECT = False
+
+log_level = 'INFO'
 if os.environ.get('RD_JOB_LOGLEVEL') == 'DEBUG':
     log_level = 'DEBUG'
 else:
-    log_level = 'INFO'
+    log_level = 'ERROR'
 
 ##end
 
@@ -231,28 +302,32 @@ log.debug("exit Behaviour:" + exitBehaviour)
 log.debug("cleanescapingflg: " + str(cleanescapingflg))
 log.debug("------------------------------------------")
 
+if not REQUESTS_INSTALLED:
+    log.error("requests is not installed, try: python -m pip install requests")
+    sys.exit(1)
+
 if not URLLIB_INSTALLED:
-    log.error("request and urllib3 not installed, try: pip install requests &&  pip install urllib3")
+    log.error("urllib3 is not installed, try: python -m pip install urllib3")
     sys.exit(1)
 
 if not WINRM_INSTALLED:
-    log.error("winrm not installed, try: pip install pywinrm")
+    log.error("winrm is not installed, try: python -m pip install pywinrm")
     sys.exit(1)
 
 if authentication == "kerberos" and not KRB_INSTALLED:
-    log.error("Kerberos not installed, try: pip install requests-kerberos")
+    log.error("Kerberos is not installed, try: python -m pip install pywinrm[kerberos]")
     sys.exit(1)
 
 if authentication == "kerberos" and not HAS_PEXPECT:
-    log.error("pexpect not installed, try: pip install pexpect")
+    log.error("pexpect is not installed, try: python -m pip install pexpect")
     sys.exit(1)
 
 if authentication == "credssp" and not HAS_CREDSSP:
-    log.error("CredSSP not installed, try: pip install pywinrm[credssp]")
+    log.error("CredSSP is not installed, try: python -m pip install pywinrm[credssp]")
     sys.exit(1)
 
 if authentication == "ntlm" and not HAS_NTLM:
-    log.error("NTLM not installed, try: pip install requests_ntlm")
+    log.error("NTLM is not installed, try: python -m pip install requests_ntlm")
     sys.exit(1)
 
 arguments = {}

--- a/contents/winrm-exec.py
+++ b/contents/winrm-exec.py
@@ -86,16 +86,6 @@ try:
     from requests_kerberos import HTTPKerberosAuth, REQUIRED, OPTIONAL, DISABLED
     KRB_INSTALLED = True
 except ImportError:
-    import pip
-    package='requests-kerberos'
-    pip.main(['install',package])
-    package='pywinrm[kerberos]'
-    pip.main(['install',package])
-
-try:
-    from requests_kerberos import HTTPKerberosAuth, REQUIRED, OPTIONAL, DISABLED
-    KRB_INSTALLED = True
-except ImportError:
     KRB_INSTALLED = False
 
 try:

--- a/contents/winrm-exec.py
+++ b/contents/winrm-exec.py
@@ -62,12 +62,6 @@ except ImportError as e:
         import pip
         package='pywinrm'
         pip.main(['install',package])
-        package='pywinrm[credssp]'
-        pip.main(['install',package])
-        package='pywinrm[kerberos]'
-        pip.main(['install',package])
-        package='pywinrm[ntlm]'
-        pip.main(['install',package])
         
         import winrm
         WINRM_INSTALLED = True
@@ -91,21 +85,23 @@ except ImportError as e:
 try:
     from requests_kerberos import HTTPKerberosAuth, REQUIRED, OPTIONAL, DISABLED
     KRB_INSTALLED = True
-except ImportError:
+except ImportError as e:
     try:
         import pip
         package='requests-kerberos'
         pip.main(['install',package])
+        package='pywinrm[kerberos]'
+        pip.main(['install',package])
 
         from requests_kerberos import HTTPKerberosAuth, REQUIRED, OPTIONAL, DISABLED
         KRB_INSTALLED = True
-    except ImportError:
+    except ImportError as e:
         KRB_INSTALLED = False
 
 try:
     from requests_ntlm import HttpNtlmAuth
     HAS_NTLM = True
-except ImportError as ie:
+except ImportError as e:
     try:
         import pip
         package='requests-ntlm'
@@ -113,21 +109,23 @@ except ImportError as ie:
 
         from requests_ntlm import HttpNtlmAuth
         HAS_NTLM = True
-    except ImportError as ie:
+    except ImportError as e:
         HAS_NTLM = False
 
 try:
     from requests_credssp import HttpCredSSPAuth
     HAS_CREDSSP = True
-except ImportError as ie:
+except ImportError as e:
     try:
         import pip
         package='requests-credssp'
         pip.main(['install',package])
+        package='pywinrm[credssp]'
+        pip.main(['install',package])
 
         from requests_credssp import HttpCredSSPAuth
         HAS_CREDSSP = True
-    except ImportError as ie:
+    except ImportError as e:
         HAS_CREDSSP = False
 
 try:

--- a/contents/winrm-exec.py
+++ b/contents/winrm-exec.py
@@ -17,12 +17,6 @@ class SuppressFilter(logging.Filter):
     def filter(self, record):
         return 'wsman' not in record.getMessage()
 
-try:
-    from urllib3.connectionpool import log
-    log.addFilter(SuppressFilter())
-except:
-    pass
-
 #checking and importing dependencies
 ISPY3 = sys.version_info[0] == 3
 WINRM_INSTALLED = False
@@ -38,114 +32,125 @@ if ISPY3:
 else:
     from inspect import getargspec
 
+## import pip module
+import pip
+
+## check urllib3
 try:
     import requests.packages.urllib3
     requests.packages.urllib3.disable_warnings()
     URLLIB_INSTALLED = True
 except ImportError as e:
-    try:
-        import pip
-        package='urllib3'
-        pip.main(['install',package])
+    package='urllib3'
+    pip.main(['install',package])
+    URLLIB_INSTALLED = False
+try:
+    import requests.packages.urllib3
+    requests.packages.urllib3.disable_warnings()
+    URLLIB_INSTALLED = True
+except ImportError as e:
+    URLLIB_INSTALLED = False
 
-        import requests.packages.urllib3
-        requests.packages.urllib3.disable_warnings()
-        URLLIB_INSTALLED = True
-    except ImportError as e:
-        URLLIB_INSTALLED = False
-
+## check pywinrm
 try:
     import winrm
     WINRM_INSTALLED = True
 except ImportError as e:
-    try:
-        import pip
-        package='pywinrm'
-        pip.main(['install',package])
-        
-        import winrm
-        WINRM_INSTALLED = True
-    except ImportError as e:
-        WINRM_INSTALLED = False
+    package='pywinrm'
+    pip.main(['install',package])
+    WINRM_INSTALLED = False
+ try:       
+    import winrm
+    WINRM_INSTALLED = True
+except ImportError as e:
+    WINRM_INSTALLED = False
 
+## check requests
 try:
     import requests
     REQUESTS_INSTALLED = True
 except ImportError as e:
-    try:
-        import pip
-        package='requests'
-        pip.main(['install',package])
-        
-        import requests
-        REQUESTS_INSTALLED = True
-    except ImportError as e:
-        REQUESTS_INSTALLED = False
+    package='requests'
+    pip.main(['install',package])
+    REQUESTS_INSTALLED = False
+try:    
+    import requests
+    REQUESTS_INSTALLED = True
+except ImportError as e:
+    REQUESTS_INSTALLED = False
 
+## check kerberos
 try:
     from requests_kerberos import HTTPKerberosAuth, REQUIRED, OPTIONAL, DISABLED
     KRB_INSTALLED = True
 except ImportError:
     KRB_INSTALLED = False
 
+## check requests ntlm
 try:
     from requests_ntlm import HttpNtlmAuth
     HAS_NTLM = True
 except ImportError as e:
-    try:
-        import pip
-        package='requests-ntlm'
-        pip.main(['install',package])
+    package='requests-ntlm'
+    pip.main(['install',package])
+    HAS_NTLM = False
+try:
+    from requests_ntlm import HttpNtlmAuth
+    HAS_NTLM = True
+except ImportError as e:
+    HAS_NTLM = False
 
-        from requests_ntlm import HttpNtlmAuth
-        HAS_NTLM = True
-    except ImportError as e:
-        HAS_NTLM = False
-
+## check requests credssp
 try:
     from requests_credssp import HttpCredSSPAuth
     HAS_CREDSSP = True
 except ImportError as e:
-    try:
-        import pip
-        package='requests-credssp'
-        pip.main(['install',package])
-        package='pywinrm[credssp]'
-        pip.main(['install',package])
+    package='requests-credssp'
+    pip.main(['install',package])
+    package='pywinrm[credssp]'
+    pip.main(['install',package])
+    HAS_CREDSSP = False
+try:
+    from requests_credssp import HttpCredSSPAuth
+    HAS_CREDSSP = True
+except ImportError as e:
+    HAS_CREDSSP = False
 
-        from requests_credssp import HttpCredSSPAuth
-        HAS_CREDSSP = True
-    except ImportError as e:
-        HAS_CREDSSP = False
-
+## check pexpect
 try:
     import pexpect
-
     if hasattr(pexpect, 'spawn'):
         argspec = getargspec(pexpect.spawn.__init__)
         if 'echo' in argspec.args:
             HAS_PEXPECT = True
 except ImportError as e:
-    try:
-        import pip
         package='pexpect'
         pip.main(['install',package])
-
-        import pexpect
-
-        if hasattr(pexpect, 'spawn'):
-            argspec = getargspec(pexpect.spawn.__init__)
-            if 'echo' in argspec.args:
-                HAS_PEXPECT = True
-    except ImportError as e:
         HAS_PEXPECT = False
+try:
+    import pexpect
+    if hasattr(pexpect, 'spawn'):
+        argspec = getargspec(pexpect.spawn.__init__)
+        if 'echo' in argspec.args:
+            HAS_PEXPECT = True
+except ImportError as e:
+    HAS_PEXPECT = False
+
+## remove pip module
+del pip
+
+## log level
+try:
+    from urllib3.connectionpool import log
+    log.addFilter(SuppressFilter())
+except:
+    pass
 
 log_level = 'INFO'
 if os.environ.get('RD_JOB_LOGLEVEL') == 'DEBUG':
     log_level = 'DEBUG'
 else:
     log_level = 'ERROR'
-
 ##end
 
 console = logging.StreamHandler()

--- a/contents/winrm-exec.py
+++ b/contents/winrm-exec.py
@@ -85,7 +85,7 @@ except ImportError as e:
 try:
     from requests_kerberos import HTTPKerberosAuth, REQUIRED, OPTIONAL, DISABLED
     KRB_INSTALLED = True
-except ImportError as e:
+except ImportError:
     import pip
     package='requests-kerberos'
     pip.main(['install',package])
@@ -95,7 +95,7 @@ except ImportError as e:
 try:
     from requests_kerberos import HTTPKerberosAuth, REQUIRED, OPTIONAL, DISABLED
     KRB_INSTALLED = True
-except ImportError as e:
+except ImportError:
     KRB_INSTALLED = False
 
 try:

--- a/contents/winrm-exec.py
+++ b/contents/winrm-exec.py
@@ -91,11 +91,12 @@ except ImportError as e:
     pip.main(['install',package])
     package='pywinrm[kerberos]'
     pip.main(['install',package])
-    try:
-        from requests_kerberos import HTTPKerberosAuth, REQUIRED, OPTIONAL, DISABLED
-        KRB_INSTALLED = True
-    except ImportError as e:
-        KRB_INSTALLED = False
+
+try:
+    from requests_kerberos import HTTPKerberosAuth, REQUIRED, OPTIONAL, DISABLED
+    KRB_INSTALLED = True
+except ImportError as e:
+    KRB_INSTALLED = False
 
 try:
     from requests_ntlm import HttpNtlmAuth

--- a/contents/winrm-exec.py
+++ b/contents/winrm-exec.py
@@ -60,8 +60,6 @@ try:
 except ImportError as e:
     try:
         import pip
-        package='winrm'
-        pip.main(['install',package])
         package='pywinrm'
         pip.main(['install',package])
         
@@ -88,13 +86,12 @@ try:
     from requests_kerberos import HTTPKerberosAuth, REQUIRED, OPTIONAL, DISABLED
     KRB_INSTALLED = True
 except ImportError as e:
+    import pip
+    package='requests-kerberos'
+    pip.main(['install',package])
+    package='pywinrm[kerberos]'
+    pip.main(['install',package])
     try:
-        import pip
-        package='requests-kerberos'
-        pip.main(['install',package])
-        package='pywinrm[kerberos]'
-        pip.main(['install',package])
-
         from requests_kerberos import HTTPKerberosAuth, REQUIRED, OPTIONAL, DISABLED
         KRB_INSTALLED = True
     except ImportError as e:

--- a/contents/winrm-filecopier.py
+++ b/contents/winrm-filecopier.py
@@ -58,7 +58,7 @@ except ImportError as e:
     package='pywinrm'
     pip.main(['install',package])
     WINRM_INSTALLED = False
- try:       
+try:   
     import winrm
     WINRM_INSTALLED = True
 except ImportError as e:
@@ -72,7 +72,7 @@ except ImportError as e:
     package='requests'
     pip.main(['install',package])
     REQUESTS_INSTALLED = False
-try:    
+try:
     import requests
     REQUESTS_INSTALLED = True
 except ImportError as e:

--- a/contents/winrm-filecopier.py
+++ b/contents/winrm-filecopier.py
@@ -31,114 +31,119 @@ if ISPY3:
 else:
     from inspect import getargspec
 
+## import pip module
+import pip
+
+## check urllib3
 try:
     import requests.packages.urllib3
     requests.packages.urllib3.disable_warnings()
     URLLIB_INSTALLED = True
 except ImportError as e:
-    try:
-        import pip
-        package='urllib3'
-        pip.main(['install',package])
+    package='urllib3'
+    pip.main(['install',package])
+    URLLIB_INSTALLED = False
+try:
+    import requests.packages.urllib3
+    requests.packages.urllib3.disable_warnings()
+    URLLIB_INSTALLED = True
+except ImportError as e:
+    URLLIB_INSTALLED = False
 
-        import requests.packages.urllib3
-        requests.packages.urllib3.disable_warnings()
-        URLLIB_INSTALLED = True
-    except ImportError as e:
-        URLLIB_INSTALLED = False
-
+## check pywinrm
 try:
     import winrm
     WINRM_INSTALLED = True
 except ImportError as e:
-    try:
-        import pip
-        package='pywinrm'
-        pip.main(['install',package])
-        
-        import winrm
-        WINRM_INSTALLED = True
-    except ImportError as e:
-        WINRM_INSTALLED = False
+    package='pywinrm'
+    pip.main(['install',package])
+    WINRM_INSTALLED = False
+ try:       
+    import winrm
+    WINRM_INSTALLED = True
+except ImportError as e:
+    WINRM_INSTALLED = False
 
+## check requests
 try:
     import requests
     REQUESTS_INSTALLED = True
 except ImportError as e:
-    try:
-        import pip
-        package='requests'
-        pip.main(['install',package])
-        
-        import requests
-        REQUESTS_INSTALLED = True
-    except ImportError as e:
-        REQUESTS_INSTALLED = False
+    package='requests'
+    pip.main(['install',package])
+    REQUESTS_INSTALLED = False
+try:    
+    import requests
+    REQUESTS_INSTALLED = True
+except ImportError as e:
+    REQUESTS_INSTALLED = False
 
+## check kerberos
 try:
     from requests_kerberos import HTTPKerberosAuth, REQUIRED, OPTIONAL, DISABLED
     KRB_INSTALLED = True
 except ImportError:
     KRB_INSTALLED = False
 
+## check requests ntlm
 try:
     from requests_ntlm import HttpNtlmAuth
     HAS_NTLM = True
 except ImportError as e:
-    try:
-        import pip
-        package='requests-ntlm'
-        pip.main(['install',package])
+    package='requests-ntlm'
+    pip.main(['install',package])
+    HAS_NTLM = False
+try:
+    from requests_ntlm import HttpNtlmAuth
+    HAS_NTLM = True
+except ImportError as e:
+    HAS_NTLM = False
 
-        from requests_ntlm import HttpNtlmAuth
-        HAS_NTLM = True
-    except ImportError as e:
-        HAS_NTLM = False
-
+## check requests credssp
 try:
     from requests_credssp import HttpCredSSPAuth
     HAS_CREDSSP = True
 except ImportError as e:
-    try:
-        import pip
-        package='requests-credssp'
-        pip.main(['install',package])
-        package='pywinrm[credssp]'
-        pip.main(['install',package])
+    package='requests-credssp'
+    pip.main(['install',package])
+    package='pywinrm[credssp]'
+    pip.main(['install',package])
+    HAS_CREDSSP = False
+try:
+    from requests_credssp import HttpCredSSPAuth
+    HAS_CREDSSP = True
+except ImportError as e:
+    HAS_CREDSSP = False
 
-        from requests_credssp import HttpCredSSPAuth
-        HAS_CREDSSP = True
-    except ImportError as e:
-        HAS_CREDSSP = False
-
+## check pexpect
 try:
     import pexpect
-
     if hasattr(pexpect, 'spawn'):
         argspec = getargspec(pexpect.spawn.__init__)
         if 'echo' in argspec.args:
             HAS_PEXPECT = True
 except ImportError as e:
-    try:
-        import pip
         package='pexpect'
         pip.main(['install',package])
-
-        import pexpect
-
-        if hasattr(pexpect, 'spawn'):
-            argspec = getargspec(pexpect.spawn.__init__)
-            if 'echo' in argspec.args:
-                HAS_PEXPECT = True
-    except ImportError as e:
         HAS_PEXPECT = False
+try:
+    import pexpect
+    if hasattr(pexpect, 'spawn'):
+        argspec = getargspec(pexpect.spawn.__init__)
+        if 'echo' in argspec.args:
+            HAS_PEXPECT = True
+except ImportError as e:
+    HAS_PEXPECT = False
 
+## remove pip module
+del pip
+
+## log level
 log_level = 'INFO'
 if os.environ.get('RD_JOB_LOGLEVEL') == 'DEBUG':
     log_level = 'DEBUG'
 else:
     log_level = 'ERROR'
-
 ##end
 
 console = logging.StreamHandler()

--- a/contents/winrm-filecopier.py
+++ b/contents/winrm-filecopier.py
@@ -24,6 +24,7 @@ KRB_INSTALLED = False
 HAS_NTLM = False
 HAS_CREDSSP = False
 HAS_PEXPECT = False
+REQUESTS_INSTALLED = False
 
 if ISPY3:
     from inspect import getfullargspec as getargspec
@@ -35,35 +36,92 @@ try:
     requests.packages.urllib3.disable_warnings()
     URLLIB_INSTALLED = True
 except ImportError as e:
-    URLLIB_INSTALLED = False
+    try:
+        import pip
+        package='urllib3'
+        pip.main(['install',package])
+
+        import requests.packages.urllib3
+        requests.packages.urllib3.disable_warnings()
+        URLLIB_INSTALLED = True
+    except ImportError as e:
+        URLLIB_INSTALLED = False
 
 try:
     import winrm
-
     WINRM_INSTALLED = True
 except ImportError as e:
-    WINRM_INSTALLED = False
+    try:
+        import pip
+        package='pywinrm'
+        pip.main(['install',package])
+        package='pywinrm[credssp]'
+        pip.main(['install',package])
+        package='pywinrm[kerberos]'
+        pip.main(['install',package])
+        package='pywinrm[ntlm]'
+        pip.main(['install',package])
+        
+        import winrm
+        WINRM_INSTALLED = True
+    except ImportError as e:
+        WINRM_INSTALLED = False
+
+try:
+    import requests
+    REQUESTS_INSTALLED = True
+except ImportError as e:
+    try:
+        import pip
+        package='requests'
+        pip.main(['install',package])
+        
+        import requests
+        REQUESTS_INSTALLED = True
+    except ImportError as e:
+        REQUESTS_INSTALLED = False
 
 try:
     from requests_kerberos import HTTPKerberosAuth, REQUIRED, OPTIONAL, DISABLED
-
     KRB_INSTALLED = True
 except ImportError:
-    KRB_INSTALLED = False
+    try:
+        import pip
+        package='requests-kerberos'
+        pip.main(['install',package])
+
+        from requests_kerberos import HTTPKerberosAuth, REQUIRED, OPTIONAL, DISABLED
+        KRB_INSTALLED = True
+    except ImportError:
+        KRB_INSTALLED = False
 
 try:
     from requests_ntlm import HttpNtlmAuth
-
     HAS_NTLM = True
 except ImportError as ie:
-    HAS_NTLM = False
+    try:
+        import pip
+        package='requests-ntlm'
+        pip.main(['install',package])
+
+        from requests_ntlm import HttpNtlmAuth
+        HAS_NTLM = True
+    except ImportError as ie:
+        HAS_NTLM = False
 
 try:
     from requests_credssp import HttpCredSSPAuth
-
     HAS_CREDSSP = True
 except ImportError as ie:
-    HAS_CREDSSP = False
+    try:
+        import pip
+        package='requests-credssp'
+        pip.main(['install',package])
+
+        from requests_credssp import HttpCredSSPAuth
+        HAS_CREDSSP = True
+    except ImportError as ie:
+        HAS_CREDSSP = False
 
 try:
     import pexpect
@@ -73,7 +131,19 @@ try:
         if 'echo' in argspec.args:
             HAS_PEXPECT = True
 except ImportError as e:
-    HAS_PEXPECT = False
+    try:
+        import pip
+        package='pexpect'
+        pip.main(['install',package])
+
+        import pexpect
+
+        if hasattr(pexpect, 'spawn'):
+            argspec = getargspec(pexpect.spawn.__init__)
+            if 'echo' in argspec.args:
+                HAS_PEXPECT = True
+    except ImportError as e:
+        HAS_PEXPECT = False
 
 log_level = 'INFO'
 if os.environ.get('RD_JOB_LOGLEVEL') == 'DEBUG':
@@ -82,13 +152,6 @@ else:
     log_level = 'ERROR'
 
 ##end
-
-
-log_level = 'INFO'
-if os.environ.get('RD_JOB_LOGLEVEL') == 'DEBUG':
-    log_level = 'DEBUG'
-else:
-    log_level = 'ERROR'
 
 console = logging.StreamHandler()
 console.setFormatter(ColoredFormatter(colored_formatter.format()))
@@ -327,29 +390,32 @@ else:
 
 arguments["credssp_disable_tlsv1_2"] = diabletls12
 
+if not REQUESTS_INSTALLED:
+    log.error("requests is not installed, try: python -m pip install requests")
+    sys.exit(1)
 
 if not URLLIB_INSTALLED:
-    log.error("request and urllib3 not installed, try: pip install requests &&  pip install urllib3")
+    log.error("urllib3 is not installed, try: python -m pip install urllib3")
     sys.exit(1)
 
 if not WINRM_INSTALLED:
-    log.error("winrm not installed, try: pip install pywinrm")
+    log.error("winrm is not installed, try: python -m pip install pywinrm")
     sys.exit(1)
 
 if authentication == "kerberos" and not KRB_INSTALLED:
-    log.error("Kerberos not installed, try: pip install pywinrm[kerberos]")
+    log.error("Kerberos is not installed, try: python -m pip install pywinrm[kerberos]")
     sys.exit(1)
 
 if authentication == "kerberos" and not HAS_PEXPECT:
-    log.error("pexpect not installed, try: pip install pexpect")
+    log.error("pexpect is not installed, try: python -m pip install pexpect")
     sys.exit(1)
 
 if authentication == "credssp" and not HAS_CREDSSP:
-    log.error("CredSSP not installed, try: pip install pywinrm[credssp]")
+    log.error("CredSSP is not installed, try: python -m pip install pywinrm[credssp]")
     sys.exit(1)
 
 if authentication == "ntlm" and not HAS_NTLM:
-    log.error("NTLM not installed, try: pip install requests_ntlm")
+    log.error("NTLM is not installed, try: python -m pip install requests_ntlm")
     sys.exit(1)
 
 if authentication == "kerberos":

--- a/contents/winrm-filecopier.py
+++ b/contents/winrm-filecopier.py
@@ -53,8 +53,6 @@ try:
 except ImportError as e:
     try:
         import pip
-        package='winrm'
-        pip.main(['install',package])
         package='pywinrm'
         pip.main(['install',package])
         
@@ -81,13 +79,12 @@ try:
     from requests_kerberos import HTTPKerberosAuth, REQUIRED, OPTIONAL, DISABLED
     KRB_INSTALLED = True
 except ImportError as e:
+    import pip
+    package='requests-kerberos'
+    pip.main(['install',package])
+    package='pywinrm[kerberos]'
+    pip.main(['install',package])
     try:
-        import pip
-        package='requests-kerberos'
-        pip.main(['install',package])
-        package='pywinrm[kerberos]'
-        pip.main(['install',package])
-
         from requests_kerberos import HTTPKerberosAuth, REQUIRED, OPTIONAL, DISABLED
         KRB_INSTALLED = True
     except ImportError as e:

--- a/contents/winrm-filecopier.py
+++ b/contents/winrm-filecopier.py
@@ -78,7 +78,7 @@ except ImportError as e:
 try:
     from requests_kerberos import HTTPKerberosAuth, REQUIRED, OPTIONAL, DISABLED
     KRB_INSTALLED = True
-except ImportError as e:
+except ImportError:
     import pip
     package='requests-kerberos'
     pip.main(['install',package])
@@ -88,7 +88,7 @@ except ImportError as e:
 try:
     from requests_kerberos import HTTPKerberosAuth, REQUIRED, OPTIONAL, DISABLED
     KRB_INSTALLED = True
-except ImportError as e:
+except ImportError:
     KRB_INSTALLED = False
 
 try:

--- a/contents/winrm-filecopier.py
+++ b/contents/winrm-filecopier.py
@@ -84,11 +84,12 @@ except ImportError as e:
     pip.main(['install',package])
     package='pywinrm[kerberos]'
     pip.main(['install',package])
-    try:
-        from requests_kerberos import HTTPKerberosAuth, REQUIRED, OPTIONAL, DISABLED
-        KRB_INSTALLED = True
-    except ImportError as e:
-        KRB_INSTALLED = False
+
+try:
+    from requests_kerberos import HTTPKerberosAuth, REQUIRED, OPTIONAL, DISABLED
+    KRB_INSTALLED = True
+except ImportError as e:
+    KRB_INSTALLED = False
 
 try:
     from requests_ntlm import HttpNtlmAuth

--- a/contents/winrm-filecopier.py
+++ b/contents/winrm-filecopier.py
@@ -55,12 +55,6 @@ except ImportError as e:
         import pip
         package='pywinrm'
         pip.main(['install',package])
-        package='pywinrm[credssp]'
-        pip.main(['install',package])
-        package='pywinrm[kerberos]'
-        pip.main(['install',package])
-        package='pywinrm[ntlm]'
-        pip.main(['install',package])
         
         import winrm
         WINRM_INSTALLED = True
@@ -84,21 +78,23 @@ except ImportError as e:
 try:
     from requests_kerberos import HTTPKerberosAuth, REQUIRED, OPTIONAL, DISABLED
     KRB_INSTALLED = True
-except ImportError:
+except ImportError as e:
     try:
         import pip
         package='requests-kerberos'
         pip.main(['install',package])
+        package='pywinrm[kerberos]'
+        pip.main(['install',package])
 
         from requests_kerberos import HTTPKerberosAuth, REQUIRED, OPTIONAL, DISABLED
         KRB_INSTALLED = True
-    except ImportError:
+    except ImportError as e:
         KRB_INSTALLED = False
 
 try:
     from requests_ntlm import HttpNtlmAuth
     HAS_NTLM = True
-except ImportError as ie:
+except ImportError as e:
     try:
         import pip
         package='requests-ntlm'
@@ -106,21 +102,23 @@ except ImportError as ie:
 
         from requests_ntlm import HttpNtlmAuth
         HAS_NTLM = True
-    except ImportError as ie:
+    except ImportError as e:
         HAS_NTLM = False
 
 try:
     from requests_credssp import HttpCredSSPAuth
     HAS_CREDSSP = True
-except ImportError as ie:
+except ImportError as e:
     try:
         import pip
         package='requests-credssp'
         pip.main(['install',package])
+        package='pywinrm[credssp]'
+        pip.main(['install',package])
 
         from requests_credssp import HttpCredSSPAuth
         HAS_CREDSSP = True
-    except ImportError as ie:
+    except ImportError as e:
         HAS_CREDSSP = False
 
 try:

--- a/contents/winrm-filecopier.py
+++ b/contents/winrm-filecopier.py
@@ -79,16 +79,6 @@ try:
     from requests_kerberos import HTTPKerberosAuth, REQUIRED, OPTIONAL, DISABLED
     KRB_INSTALLED = True
 except ImportError:
-    import pip
-    package='requests-kerberos'
-    pip.main(['install',package])
-    package='pywinrm[kerberos]'
-    pip.main(['install',package])
-
-try:
-    from requests_kerberos import HTTPKerberosAuth, REQUIRED, OPTIONAL, DISABLED
-    KRB_INSTALLED = True
-except ImportError:
     KRB_INSTALLED = False
 
 try:

--- a/contents/winrm-filecopier.py
+++ b/contents/winrm-filecopier.py
@@ -53,6 +53,8 @@ try:
 except ImportError as e:
     try:
         import pip
+        package='winrm'
+        pip.main(['install',package])
         package='pywinrm'
         pip.main(['install',package])
         

--- a/contents/winrm_session.py
+++ b/contents/winrm_session.py
@@ -7,7 +7,7 @@ except:
 	os.environ.setdefault('PATH', '')
 try:
     from StringIO import StringIO
-except ImportError:
+except ImportError as e:
     from io import StringIO
 try:
     from BytesIO import BytesIO
@@ -17,7 +17,7 @@ except ImportError as e:
 try:
     import protocol
     import winrm
-except ImportError:
+except ImportError as e:
     pass
 
 import base64


### PR DESCRIPTION
py-winrm-plugin dependency auto install (except kerberos)

_**disclaimer**: it fails the first time because for some reason does not take the **WINRM_INSTALLED** validity check, but the second time works as a charm_