### PR TITLE
RSE-784 Fix: Pywinrm does not work on rehl 7

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ Download from the releases page and copy the py-winrm-plugin-X.X.X.zip to the li
 * Linux, Mac OS X or Windows
 * CPython 2.6-2.7, 3.3-3.5 or PyPy2
 * pywinrm
+* openssl 1.1.1 or higher
 * requests-kerberos and requests-credssp is optional
 
 It can be installed with the following command: `pip install pywinrm` 


### PR DESCRIPTION
Problem: pyWinrm does not work on RHEL7 (Red Hat Enterprise Linux 7). An error occurs indicating that urllib3 2.x requires OpenSSL 1.1.1 

Solution: Add openssl version 1.1.1 or higher as a requirement for pyWinrm to function.