### PR TITLE
RUN-2098: retry connection and increase connection logging

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,10 @@ For further information see:
 It can be overwriting at node level using `winrm-readtimeout`
 * **operation timeout**: maximum allowed time in seconds for any single wsman HTTP operation (default 20). Note that operation timeouts while receiving output (the only wsman operation that should take any significant time, and where these timeouts are expected) will be silently retried indefinitely.
 It can be overwriting at node level using `winrm-operationtimeout`
+* **retry connection**: Retry a connection when it fails for connectivity issues (default 1).  
+  It can be overwriting at node level using `winrm-retry-connection`
+* **retry connection**: Delay between retries in seconds (default 10 seconds).
+  It can be overwriting at node level using `winrm-retry-connection-delay`
 
 For Kerberos
 * **krb5 Config File**: path of the krb5.conf (default: /etc/krb5.conf)

--- a/contents/winrm-exec.py
+++ b/contents/winrm-exec.py
@@ -135,6 +135,9 @@ forcefail = False
 exitBehaviour = "console"
 cleanescapingflg = False
 enabledHttpDebug = False
+retryconnection = 1
+retryconnectiondelay = 0
+username = None
 
 if "RD_CONFIG_AUTHTYPE" in os.environ:
     authentication = os.getenv("RD_CONFIG_AUTHTYPE")
@@ -186,6 +189,12 @@ if "RD_CONFIG_ENABLEDHTTPDEBUG" in os.environ:
         enabledHttpDebug = True
     else:
         enabledHttpDebug = False
+
+if "RD_CONFIG_RETRYCONNECTION" in os.environ:
+    retryconnection = int(os.getenv("RD_CONFIG_RETRYCONNECTION"))
+
+if "RD_CONFIG_RETRYCONNECTIONDELAY" in os.environ:
+    retryconnectiondelay = int(os.getenv("RD_CONFIG_RETRYCONNECTIONDELAY"))
 
 exec_command = os.getenv("RD_EXEC_COMMAND")
 log.debug("Command will be executed: " + exec_command)
@@ -243,8 +252,8 @@ log.debug("authentication:" + authentication)
 log.debug("username:" + username)
 log.debug("nossl:" + str(nossl))
 log.debug("diabletls12:" + str(diabletls12))
-log.debug("krb5config:" + krb5config)
-log.debug("kinit command:" + kinit)
+log.debug("krb5config:" + str(krb5config))
+log.debug("kinit command:" + str(kinit))
 log.debug("kerberos delegation:" + str(krbdelegation))
 log.debug("shell:" + shell)
 log.debug("output_charset:" + output_charset)
@@ -253,6 +262,8 @@ log.debug("operationtimeout:" + str(operationtimeout))
 log.debug("exit Behaviour:" + exitBehaviour)
 log.debug("cleanescapingflg: " + str(cleanescapingflg))
 log.debug("enabledHttpDebug: " + str(enabledHttpDebug))
+log.debug("retryConnection: " + str(retryconnection))
+log.debug("retryConnectionDelay: " + str(retryconnectiondelay))
 log.debug("------------------------------------------")
 
 if enabledHttpDebug:
@@ -314,7 +325,7 @@ winrm.Session.run_ps = winrm_session.run_ps
 winrm.Session._clean_error_msg = winrm_session._clean_error_msg
 winrm.Session._strip_namespace = winrm_session._strip_namespace
 
-tsk = winrm_session.RunCommand(session, shell, exec_command, output_charset)
+tsk = winrm_session.RunCommand(session, shell, exec_command, retryconnection, retryconnectiondelay, output_charset)
 t = threading.Thread(target=tsk.get_response)
 t.start()
 realstdout = sys.stdout

--- a/contents/winrm-exec.py
+++ b/contents/winrm-exec.py
@@ -181,8 +181,8 @@ if "RD_CONFIG_CLEANESCAPING" in os.environ:
      else:
         cleanescapingflg = False
 
-if "RD_CONFIG_ENABLEHTTPDEBUG" in os.environ:
-    if os.getenv("RD_CONFIG_ENABLEHTTPDEBUG") == "true":
+if "RD_CONFIG_ENABLEDHTTPDEBUG" in os.environ:
+    if os.getenv("RD_CONFIG_ENABLEDHTTPDEBUG") == "true":
         enabledHttpDebug = True
     else:
         enabledHttpDebug = False

--- a/contents/winrm-filecopier.py
+++ b/contents/winrm-filecopier.py
@@ -256,6 +256,8 @@ krbdelegation = False
 forceTicket = False
 override=False
 enabledHttpDebug = False
+readtimeout = None
+operationtimeout = None
 
 if os.environ.get('RD_CONFIG_OVERRIDE') == 'true':
     override = True
@@ -325,8 +327,8 @@ if "RD_CONFIG_READTIMEOUT" in os.environ:
 if "RD_CONFIG_OPERATIONTIMEOUT" in os.environ:
     operationtimeout = os.getenv("RD_CONFIG_OPERATIONTIMEOUT")
 
-if "RD_CONFIG_ENABLEHTTPDEBUG" in os.environ:
-    if os.getenv("RD_CONFIG_ENABLEHTTPDEBUG") == "true":
+if "RD_CONFIG_ENABLEDHTTPDEBUG" in os.environ:
+    if os.getenv("RD_CONFIG_ENABLEDHTTPDEBUG") == "true":
         enabledHttpDebug = True
     else:
         enabledHttpDebug = False
@@ -335,7 +337,6 @@ if enabledHttpDebug:
     httpclient_logging_patch(logging.DEBUG)
 
 endpoint = transport+'://'+args.hostname+':'+port
-
 arguments = {}
 arguments["transport"] = authentication
 

--- a/plugin.yaml
+++ b/plugin.yaml
@@ -183,6 +183,16 @@ providers:
         renderingOptions:
           groupName: Misc
           instance-scope-node-attribute: "clean-escaping"
+      - name: enabledhttpdebug
+        title: Enable HTTP logging in debug mode
+        description: "Print extra http logging in debug mode"
+        type: Boolean
+        default: "false"
+        required: true
+        scope: Instance
+        renderingOptions:
+          groupName: Connection
+          instance-scope-node-attribute: "winrm-enable-http-logging"
   - name: WinRMcpPython
     title: WinRM Python File Copier
     description: Copying files to remote Windows computer
@@ -262,6 +272,24 @@ providers:
         renderingOptions:
           groupName: Connection
           instance-scope-node-attribute: "winrm-certpath"
+      - name: readtimeout
+        title: connect/read times out
+        description: "maximum seconds to wait before an HTTP connect/read times out (default 30). This value should be slightly higher than operation timeout, as the server can block *at least* that long. It can be overwriting at node level using `winrm-readtimeout`"
+        type: String
+        required: false
+        scope: Instance
+        renderingOptions:
+          groupName: Connection
+          instance-scope-node-attribute: "winrm-readtimeout"
+      - name: operationtimeout
+        title: operation timeout
+        description: "maximum allowed time in seconds for any single wsman HTTP operation (default 20). Note that operation timeouts while receiving output (the only wsman operation that should take any significant time, and where these timeouts are expected) will be silently retried indefinitely. It can be overwriting at node level using `winrm-operationtimeout`"
+        type: String
+        required: false
+        scope: Instance
+        renderingOptions:
+          groupName: Connection
+          instance-scope-node-attribute: "winrm-operationtimeout"
       - name: username
         title: Username
         type: String
@@ -314,6 +342,16 @@ providers:
         required: false
         renderingOptions:
           groupName: Kerberos
+      - name: enabledhttpdebug
+        title: Enable HTTP logging in debug mode
+        description: "Print extra http logging in debug mode"
+        type: Boolean
+        default: "false"
+        required: true
+        scope: Instance
+        renderingOptions:
+          groupName: Connection
+          instance-scope-node-attribute: "winrm-enable-http-logging"
   - name: WinRMCheck
     title: WinRM Check Step
     description: Check the connection with a remote node using winrm-python

--- a/plugin.yaml
+++ b/plugin.yaml
@@ -193,6 +193,26 @@ providers:
         renderingOptions:
           groupName: Connection
           instance-scope-node-attribute: "winrm-enable-http-logging"
+      - name: retryconnection
+        title: Retry connection
+        description: "Retry the connection to the node if the connection fails. It can be overwriting at node level using `winrm-retry-connection`"
+        type: Integer
+        default: "1"
+        required: false
+        scope: Instance
+        renderingOptions:
+          groupName: Connection
+          instance-scope-node-attribute: "winrm-retry-connection"
+      - name: retryconnectiondelay
+        title: Retry connection delay
+        description: "Delay between each retry atten (seconds). It can be overwriting at node level using `winrm-retry-connection-delay`"
+        type: Integer
+        default: "10"
+        required: false
+        scope: Instance
+        renderingOptions:
+          groupName: Connection
+          instance-scope-node-attribute: "winrm-retry-connection-delay"
   - name: WinRMcpPython
     title: WinRM Python File Copier
     description: Copying files to remote Windows computer
@@ -352,6 +372,26 @@ providers:
         renderingOptions:
           groupName: Connection
           instance-scope-node-attribute: "winrm-enable-http-logging"
+      - name: retryconnection
+        title: Retry connection
+        description: "Retry the connection to the node if the connection fails. It can be overwriting at node level using `winrm-retry-connection`"
+        type: Integer
+        default: "1"
+        required: false
+        scope: Instance
+        renderingOptions:
+          groupName: Connection
+          instance-scope-node-attribute: "winrm-retry-connection"
+      - name: retryconnectiondelay
+        title: Retry connection delay
+        description: "Delay between each retry atten (seconds). It can be overwriting at node level using `winrm-retry-connection-delay`"
+        type: Integer
+        default: "10"
+        required: false
+        scope: Instance
+        renderingOptions:
+          groupName: Connection
+          instance-scope-node-attribute: "winrm-retry-connection-delay"
   - name: WinRMCheck
     title: WinRM Check Step
     description: Check the connection with a remote node using winrm-python


### PR DESCRIPTION
- retry connection mechanisms 
    * **retry connection**: Retry a connection when it fails for connectivity issues (default 1).  
      It can be overwriting at node level using `winrm-retry-connection`
    * **retry connection**: Delay between retries in seconds (default 10 seconds).
      It can be overwriting at node level using `winrm-retry-connection-delay`

- adding an option to debug HTTP logging
- pass timeout and operation timeout to the file copier