### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,6 +110,7 @@ In resume, to use Kerberos authentication the following requirements are needed:
 
 ```bash
 $ sudo apt-get install python-dev libkrb5-dev
+$ pip install wheel
 $ pip install pywinrm[kerberos]
 $ pip install requests-kerberos
 $ pip install pexpect
@@ -117,7 +118,8 @@ $ pip install pexpect
 
 #### for RHEL/CentOS/etc:
 ```bash
-$ sudo yum install python-devel krb5-devel krb5-workstation requests-kerberos
+$ sudo yum install python-devel krb5-devel krb5-workstation gcc
+$ pip install wheel
 $ pip install pywinrm[kerberos]
 $ pip install requests-kerberos
 $ pip install pexpect


### PR DESCRIPTION
changing requests-kerberos package from yum to GCC, which is a missing compiler to compile pywinrm[kerberos]. requests-kerberos can be installed through pip which is recommended (and it is already on the pip install list).

wheel also is required to compile pywinrm[kerberos].