### PR TITLE
feat: allow defining arbitrary python interpreter for newer distros

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,22 +1,231 @@
-# Created by https://www.gitignore.io/api/java,gradle
+# Created by https://www.toptal.com/developers/gitignore/api/python,java,gradle
+# Edit at https://www.toptal.com/developers/gitignore?templates=python,java,gradle
 
+### Java ###
+# Compiled class file
+*.class
+
+# Log file
+*.log
+
+# BlueJ files
+*.ctxt
+
+# Mobile Tools for Java (J2ME)
+.mtj.tmp/
+
+# Package Files #
+*.jar
+*.war
+*.nar
+*.ear
+*.zip
+*.tar.gz
+*.rar
+
+# virtual machine crash logs, see http://www.java.com/en/download/help/error_hotspot.xml
+hs_err_pid*
+replay_pid*
+
+### Python ###
+# Byte-compiled / optimized / DLL files
+__pycache__/
+*.py[cod]
+*$py.class
+
+# C extensions
+*.so
+
+# Distribution / packaging
+.Python
+build/
+develop-eggs/
+dist/
+downloads/
+eggs/
+.eggs/
+lib/
+lib64/
+parts/
+sdist/
+var/
+wheels/
+share/python-wheels/
+*.egg-info/
+.installed.cfg
+*.egg
+MANIFEST
+
+# PyInstaller
+#  Usually these files are written by a python script from a template
+#  before PyInstaller builds the exe, so as to inject date/other infos into it.
+*.manifest
+*.spec
+
+# Installer logs
+pip-log.txt
+pip-delete-this-directory.txt
+
+# Unit test / coverage reports
+htmlcov/
+.tox/
+.nox/
+.coverage
+.coverage.*
+.cache
+nosetests.xml
+coverage.xml
+*.cover
+*.py,cover
+.hypothesis/
+.pytest_cache/
+cover/
+
+# Translations
+*.mo
+*.pot
+
+# Django stuff:
+local_settings.py
+db.sqlite3
+db.sqlite3-journal
+
+# Flask stuff:
+instance/
+.webassets-cache
+
+# Scrapy stuff:
+.scrapy
+
+# Sphinx documentation
+docs/_build/
+
+# PyBuilder
+.pybuilder/
+target/
+
+# Jupyter Notebook
+.ipynb_checkpoints
+
+# IPython
+profile_default/
+ipython_config.py
+
+# pyenv
+#   For a library or package, you might want to ignore these files since the code is
+#   intended to run in multiple environments; otherwise, check them in:
+# .python-version
+
+# pipenv
+#   According to pypa/pipenv#598, it is recommended to include Pipfile.lock in version control.
+#   However, in case of collaboration, if having platform-specific dependencies or dependencies
+#   having no cross-platform support, pipenv may install dependencies that don't work, or not
+#   install all needed dependencies.
+#Pipfile.lock
+
+# poetry
+#   Similar to Pipfile.lock, it is generally recommended to include poetry.lock in version control.
+#   This is especially recommended for binary packages to ensure reproducibility, and is more
+#   commonly ignored for libraries.
+#   https://python-poetry.org/docs/basic-usage/#commit-your-poetrylock-file-to-version-control
+#poetry.lock
+
+# pdm
+#   Similar to Pipfile.lock, it is generally recommended to include pdm.lock in version control.
+#pdm.lock
+#   pdm stores project-wide configurations in .pdm.toml, but it is recommended to not include it
+#   in version control.
+#   https://pdm.fming.dev/#use-with-ide
+.pdm.toml
+
+# PEP 582; used by e.g. github.com/David-OConnor/pyflow and github.com/pdm-project/pdm
+__pypackages__/
+
+# Celery stuff
+celerybeat-schedule
+celerybeat.pid
+
+# SageMath parsed files
+*.sage.py
+
+# Environments
+.env
+.venv
+env/
+venv/
+ENV/
+env.bak/
+venv.bak/
+
+# Spyder project settings
+.spyderproject
+.spyproject
+
+# Rope project settings
+.ropeproject
+
+# mkdocs documentation
+/site
+
+# mypy
+.mypy_cache/
+.dmypy.json
+dmypy.json
+
+# Pyre type checker
+.pyre/
+
+# pytype static type analyzer
+.pytype/
+
+# Cython debug symbols
+cython_debug/
+
+# PyCharm
+#  JetBrains specific template is maintained in a separate JetBrains.gitignore that can
+#  be found at https://github.com/github/gitignore/blob/main/Global/JetBrains.gitignore
+#  and can be added to the global gitignore or merged into this file.  For a more nuclear
+#  option (not recommended) you can uncomment the following to ignore the entire idea folder.
+#.idea/
+
+### Python Patch ###
+# Poetry local configuration file - https://python-poetry.org/docs/configuration/#local-configuration
+poetry.toml
+
+# ruff
+.ruff_cache/
+
+# LSP config files
+pyrightconfig.json
 
 ### Gradle ###
 .gradle
-.idea
-/build/
-/docker/rundeck/plugins/py-winrm-plugin-*
-/docker/resources/*.xml
+**/build/
+!src/**/build/
+
 # Ignore Gradle GUI config
 gradle-app.setting
 
 # Avoid ignoring Gradle wrapper jar file (.jar files are usually ignored)
 !gradle-wrapper.jar
 
+# Avoid ignore Gradle wrappper properties
+!gradle-wrapper.properties
+
 # Cache of project
 .gradletasknamecache
 
-# # Work around https://youtrack.jetbrains.com/issue/IDEA-116898
-# gradle/wrapper/gradle-wrapper.properties
+# Eclipse Gradle plugin generated files
+# Eclipse Core
+.project
+# JDT-specific (Eclipse Java Development Tools)
+.classpath
 
-# End of https://www.gitignore.io/api/java,gradle
+### Gradle Patch ###
+# Java heap dump
+*.hprof
+
+# End of https://www.toptal.com/developers/gitignore/api/python,java,gradle
+
+/docker/rundeck/plugins/py-winrm-plugin-*
+/docker/resources/*.xml

--- a/contents/winrm-check.py
+++ b/contents/winrm-check.py
@@ -9,7 +9,8 @@ import logging
 import colored_formatter
 from colored_formatter import ColoredFormatter
 import kerberosauth
-
+import sysconfig
+import os.path
 
 #checking and importing dependencies
 ISPY3 = sys.version_info[0] == 3
@@ -19,6 +20,7 @@ KRB_INSTALLED = False
 HAS_NTLM = False
 HAS_CREDSSP = False
 HAS_PEXPECT = False
+SYSTEM_INTERPRETER = False
 
 if ISPY3:
     from inspect import getfullargspec as getargspec
@@ -69,6 +71,12 @@ try:
             HAS_PEXPECT = True
 except ImportError as e:
     HAS_PEXPECT = False
+
+try:
+    externally_managed_path = os.path.join(sysconfig.get_path("stdlib"), "EXTERNALLY-MANAGED")
+    SYSTEM_INTERPRETER = os.path.exists(externally_managed_path)
+except:
+    SYSTEM_INTERPRETER = False
 
 log_level = 'INFO'
 if os.environ.get('RD_JOB_LOGLEVEL') == 'DEBUG':
@@ -207,28 +215,67 @@ if(certpath):
 log.debug("------------------------------------------")
 
 
+URLLIB_ERRORMESSAGE_BASE = "requests and urllib3 not installed"
+WINRM_ERRORMESSAGE_BASE = "pywinrm not installed"
+KRB_ERRORMESSAGE_BASE = "requests-kerberos not installed"
+PEXPECT_ERRORMESSAGE_BASE = "pexpect not installed"
+CREDSSP_ERRORMESSAGE_BASE = "pywinrm[credssp] not installed"
+NTLM_ERRORMESSAGE_BASE = "requests-ntlm not installed"
+
+if SYSTEM_INTERPRETER:
+    import configparser
+    externally_managed_file = configparser.RawConfigParser()
+    externally_managed_file.read(externally_managed_path)
+    SYSTEM_INTERPRETER_ERRORMESSAGE=externally_managed_file.get("externally-managed", "Error")
+
+    ERRORMESSAGE = ", please install it using your systems package manager or consider using a virtual environment.\n{}".format(SYSTEM_INTERPRETER_ERRORMESSAGE)
+    URLLIB_ERRORMESSAGE = "{}{}".format(URLLIB_ERRORMESSAGE_BASE, ERRORMESSAGE)
+    WINRM_ERRORMESSAGE = "{}{}".format(WINRM_ERRORMESSAGE_BASE, ERRORMESSAGE)
+    KRB_ERRORMESSAGE = "{}{}".format(KRB_ERRORMESSAGE_BASE, ERRORMESSAGE)
+    PEXPECT_ERRORMESSAGE = "{}{}".format(PEXPECT_ERRORMESSAGE_BASE, ERRORMESSAGE)
+    CREDSSP_ERRORMESSAGE = "{}{}".format(CREDSSP_ERRORMESSAGE_BASE, ERRORMESSAGE)
+    NTLM_ERRORMESSAGE = "{}{}".format(NTLM_ERRORMESSAGE_BASE, ERRORMESSAGE)
+else:
+    python_executable_basename = os.path.dirname(sys.executable)
+    python_pip_executable = os.path.join(python_executable_basename, "pip3" if ISPY3 else "pip")
+    URLLIB_ERRORMESSAGE = "{}, try: {} install requests urllib3".format(URLLIB_ERRORMESSAGE_BASE, python_pip_executable)
+    WINRM_ERRORMESSAGE = "{}, try: {} install pywinrm".format(WINRM_ERRORMESSAGE_BASE, python_pip_executable)
+    KRB_ERRORMESSAGE = "{}, try: {} install requests-kerberos".format(KRB_ERRORMESSAGE_BASE, python_pip_executable)
+    PEXPECT_ERRORMESSAGE = "{}, try: {} install pexpect".format(PEXPECT_ERRORMESSAGE_BASE, python_pip_executable)
+    CREDSSP_ERRORMESSAGE = "{}, try: {} install pywinrm[credssp]".format(CREDSSP_ERRORMESSAGE_BASE, python_pip_executable)
+    NTLM_ERRORMESSAGE = "{}, try: {} install requests-ntlm".format(NTLM_ERRORMESSAGE_BASE, python_pip_executable)
+
+
+if enabledHttpDebug:
+    httpclient_logging_patch(logging.DEBUG)
+
+PACKAGE_ERROR = False
+
 if not URLLIB_INSTALLED:
-    log.error("request and urllib3 not installed, try: pip install requests &&  pip install urllib3")
-    sys.exit(1)
+    log.error(URLLIB_ERRORMESSAGE)
+    PACKAGE_ERROR = True
 
 if not WINRM_INSTALLED:
-    log.error("winrm not installed, try: pip install pywinrm")
-    sys.exit(1)
+    log.error(WINRM_ERRORMESSAGE)
+    PACKAGE_ERROR = True
 
 if authentication == "kerberos" and not KRB_INSTALLED:
-    log.error("Kerberos not installed, try: pip install requests-kerberos")
-    sys.exit(1)
+    log.error(KRB_ERRORMESSAGE)
+    PACKAGE_ERROR = True
 
 if authentication == "kerberos" and not HAS_PEXPECT:
-    log.error("pexpect not installed, try: pip install pexpect")
-    sys.exit(1)
+    log.error(PEXPECT_ERRORMESSAGE)
+    PACKAGE_ERROR = True
 
 if authentication == "credssp" and not HAS_CREDSSP:
-    log.error("CredSSP not installed, try: pip install pywinrm[credssp]")
-    sys.exit(1)
+    log.error(CREDSSP_ERRORMESSAGE)
+    PACKAGE_ERROR = True
 
 if authentication == "ntlm" and not HAS_NTLM:
-    log.error("NTLM not installed, try: pip install requests_ntlm")
+    log.error(NTLM_ERRORMESSAGE)
+    PACKAGE_ERROR = True
+
+if PACKAGE_ERROR:
     sys.exit(1)
 
 arguments={}

--- a/contents/winrm-check.py
+++ b/contents/winrm-check.py
@@ -236,14 +236,12 @@ if SYSTEM_INTERPRETER:
     CREDSSP_ERRORMESSAGE = "{}{}".format(CREDSSP_ERRORMESSAGE_BASE, ERRORMESSAGE)
     NTLM_ERRORMESSAGE = "{}{}".format(NTLM_ERRORMESSAGE_BASE, ERRORMESSAGE)
 else:
-    python_executable_basename = os.path.dirname(sys.executable)
-    python_pip_executable = os.path.join(python_executable_basename, "pip3" if ISPY3 else "pip")
-    URLLIB_ERRORMESSAGE = "{}, try: {} install requests urllib3".format(URLLIB_ERRORMESSAGE_BASE, python_pip_executable)
-    WINRM_ERRORMESSAGE = "{}, try: {} install pywinrm".format(WINRM_ERRORMESSAGE_BASE, python_pip_executable)
-    KRB_ERRORMESSAGE = "{}, try: {} install requests-kerberos".format(KRB_ERRORMESSAGE_BASE, python_pip_executable)
-    PEXPECT_ERRORMESSAGE = "{}, try: {} install pexpect".format(PEXPECT_ERRORMESSAGE_BASE, python_pip_executable)
-    CREDSSP_ERRORMESSAGE = "{}, try: {} install pywinrm[credssp]".format(CREDSSP_ERRORMESSAGE_BASE, python_pip_executable)
-    NTLM_ERRORMESSAGE = "{}, try: {} install requests-ntlm".format(NTLM_ERRORMESSAGE_BASE, python_pip_executable)
+    URLLIB_ERRORMESSAGE = "{}, try: {} -m pip install requests urllib3".format(URLLIB_ERRORMESSAGE_BASE, sys.executable)
+    WINRM_ERRORMESSAGE = "{}, try: {} -m pip install pywinrm".format(WINRM_ERRORMESSAGE_BASE, sys.executable)
+    KRB_ERRORMESSAGE = "{}, try: {} -m pip install requests-kerberos".format(KRB_ERRORMESSAGE_BASE, sys.executable)
+    PEXPECT_ERRORMESSAGE = "{}, try: {} -m pip install pexpect".format(PEXPECT_ERRORMESSAGE_BASE, sys.executable)
+    CREDSSP_ERRORMESSAGE = "{}, try: {} -m pip install pywinrm[credssp]".format(CREDSSP_ERRORMESSAGE_BASE, sys.executable)
+    NTLM_ERRORMESSAGE = "{}, try: {} -m pip install requests-ntlm".format(NTLM_ERRORMESSAGE_BASE, sys.executable)
 
 
 if enabledHttpDebug:

--- a/contents/winrm-check.py
+++ b/contents/winrm-check.py
@@ -75,7 +75,10 @@ except ImportError as e:
 try:
     externally_managed_path = os.path.join(sysconfig.get_path("stdlib"), "EXTERNALLY-MANAGED")
     SYSTEM_INTERPRETER = os.path.exists(externally_managed_path)
-except:
+except Exception as e:
+    logging.getLogger(__name__).debug(
+        "Failed to determine externally-managed status: %s", e, exc_info=True
+    )
     SYSTEM_INTERPRETER = False
 
 log_level = 'INFO'
@@ -225,8 +228,11 @@ NTLM_ERRORMESSAGE_BASE = "requests-ntlm not installed"
 if SYSTEM_INTERPRETER:
     import configparser
     externally_managed_file = configparser.RawConfigParser()
-    externally_managed_file.read(externally_managed_path)
-    SYSTEM_INTERPRETER_ERRORMESSAGE=externally_managed_file.get("externally-managed", "Error")
+    try:
+        externally_managed_file.read(externally_managed_path)
+        SYSTEM_INTERPRETER_ERRORMESSAGE = externally_managed_file.get("externally-managed", "Error")
+    except configparser.Error:
+        SYSTEM_INTERPRETER_ERRORMESSAGE = "This Python interpreter is externally managed. Please refer to your system's EXTERNALLY-MANAGED file or documentation for details."
 
     ERRORMESSAGE = ", please install it using your systems package manager or consider using a virtual environment.\n{}".format(SYSTEM_INTERPRETER_ERRORMESSAGE)
     URLLIB_ERRORMESSAGE = "{}{}".format(URLLIB_ERRORMESSAGE_BASE, ERRORMESSAGE)

--- a/contents/winrm-exec.py
+++ b/contents/winrm-exec.py
@@ -300,14 +300,12 @@ if SYSTEM_INTERPRETER:
     CREDSSP_ERRORMESSAGE = "{}{}".format(CREDSSP_ERRORMESSAGE_BASE, ERRORMESSAGE)
     NTLM_ERRORMESSAGE = "{}{}".format(NTLM_ERRORMESSAGE_BASE, ERRORMESSAGE)
 else:
-    python_executable_basename = os.path.dirname(sys.executable)
-    python_pip_executable = os.path.join(python_executable_basename, "pip3" if ISPY3 else "pip")
-    URLLIB_ERRORMESSAGE = "{}, try: {} install requests urllib3".format(URLLIB_ERRORMESSAGE_BASE, python_pip_executable)
-    WINRM_ERRORMESSAGE = "{}, try: {} install pywinrm".format(WINRM_ERRORMESSAGE_BASE, python_pip_executable)
-    KRB_ERRORMESSAGE = "{}, try: {} install requests-kerberos".format(KRB_ERRORMESSAGE_BASE, python_pip_executable)
-    PEXPECT_ERRORMESSAGE = "{}, try: {} install pexpect".format(PEXPECT_ERRORMESSAGE_BASE, python_pip_executable)
-    CREDSSP_ERRORMESSAGE = "{}, try: {} install pywinrm[credssp]".format(CREDSSP_ERRORMESSAGE_BASE, python_pip_executable)
-    NTLM_ERRORMESSAGE = "{}, try: {} install requests-ntlm".format(NTLM_ERRORMESSAGE_BASE, python_pip_executable)
+    URLLIB_ERRORMESSAGE = "{}, try: {} -m pip install requests urllib3".format(URLLIB_ERRORMESSAGE_BASE, sys.executable)
+    WINRM_ERRORMESSAGE = "{}, try: {} -m pip install pywinrm".format(WINRM_ERRORMESSAGE_BASE, sys.executable)
+    KRB_ERRORMESSAGE = "{}, try: {} -m pip install requests-kerberos".format(KRB_ERRORMESSAGE_BASE, sys.executable)
+    PEXPECT_ERRORMESSAGE = "{}, try: {} -m pip install pexpect".format(PEXPECT_ERRORMESSAGE_BASE, sys.executable)
+    CREDSSP_ERRORMESSAGE = "{}, try: {} -m pip install pywinrm[credssp]".format(CREDSSP_ERRORMESSAGE_BASE, sys.executable)
+    NTLM_ERRORMESSAGE = "{}, try: {} -m pip install requests-ntlm".format(NTLM_ERRORMESSAGE_BASE, sys.executable)
 
 
 if enabledHttpDebug:

--- a/contents/winrm-exec.py
+++ b/contents/winrm-exec.py
@@ -12,6 +12,8 @@ import colored_formatter
 import kerberosauth
 import common
 from colored_formatter import ColoredFormatter
+import sysconfig
+import os.path
 
 class SuppressFilter(logging.Filter):
     def filter(self, record):
@@ -34,7 +36,6 @@ def httpclient_logging_patch(level=logging.DEBUG):
     http.client.print = httpclient_log
     http.client.HTTPConnection.debuglevel = 1
 
-
 #checking and importing dependencies
 ISPY3 = sys.version_info[0] == 3
 WINRM_INSTALLED = False
@@ -43,6 +44,7 @@ KRB_INSTALLED = False
 HAS_NTLM = False
 HAS_CREDSSP = False
 HAS_PEXPECT = False
+SYSTEM_INTERPRETER = False
 
 if ISPY3:
     from inspect import getfullargspec as getargspec
@@ -93,6 +95,12 @@ try:
             HAS_PEXPECT = True
 except ImportError as e:
     HAS_PEXPECT = False
+
+try:
+    externally_managed_path = os.path.join(sysconfig.get_path("stdlib"), "EXTERNALLY-MANAGED")
+    SYSTEM_INTERPRETER = os.path.exists(externally_managed_path)
+except:
+    SYSTEM_INTERPRETER = False
 
 if os.environ.get('RD_JOB_LOGLEVEL') == 'DEBUG':
     log_level = 'DEBUG'
@@ -271,31 +279,67 @@ log.debug("retryConnection: " + str(retryconnection))
 log.debug("retryConnectionDelay: " + str(retryconnectiondelay))
 log.debug("------------------------------------------")
 
+URLLIB_ERRORMESSAGE_BASE = "requests and urllib3 not installed"
+WINRM_ERRORMESSAGE_BASE = "pywinrm not installed"
+KRB_ERRORMESSAGE_BASE = "requests-kerberos not installed"
+PEXPECT_ERRORMESSAGE_BASE = "pexpect not installed"
+CREDSSP_ERRORMESSAGE_BASE = "pywinrm[credssp] not installed"
+NTLM_ERRORMESSAGE_BASE = "requests-ntlm not installed"
+
+if SYSTEM_INTERPRETER:
+    import configparser
+    externally_managed_file = configparser.RawConfigParser()
+    externally_managed_file.read(externally_managed_path)
+    SYSTEM_INTERPRETER_ERRORMESSAGE=externally_managed_file.get("externally-managed", "Error")
+
+    ERRORMESSAGE = ", please install it using your systems package manager or consider using a virtual environment.\n{}".format(SYSTEM_INTERPRETER_ERRORMESSAGE)
+    URLLIB_ERRORMESSAGE = "{}{}".format(URLLIB_ERRORMESSAGE_BASE, ERRORMESSAGE)
+    WINRM_ERRORMESSAGE = "{}{}".format(WINRM_ERRORMESSAGE_BASE, ERRORMESSAGE)
+    KRB_ERRORMESSAGE = "{}{}".format(KRB_ERRORMESSAGE_BASE, ERRORMESSAGE)
+    PEXPECT_ERRORMESSAGE = "{}{}".format(PEXPECT_ERRORMESSAGE_BASE, ERRORMESSAGE)
+    CREDSSP_ERRORMESSAGE = "{}{}".format(CREDSSP_ERRORMESSAGE_BASE, ERRORMESSAGE)
+    NTLM_ERRORMESSAGE = "{}{}".format(NTLM_ERRORMESSAGE_BASE, ERRORMESSAGE)
+else:
+    python_executable_basename = os.path.dirname(sys.executable)
+    python_pip_executable = os.path.join(python_executable_basename, "pip3" if ISPY3 else "pip")
+    URLLIB_ERRORMESSAGE = "{}, try: {} install requests urllib3".format(URLLIB_ERRORMESSAGE_BASE, python_pip_executable)
+    WINRM_ERRORMESSAGE = "{}, try: {} install pywinrm".format(WINRM_ERRORMESSAGE_BASE, python_pip_executable)
+    KRB_ERRORMESSAGE = "{}, try: {} install requests-kerberos".format(KRB_ERRORMESSAGE_BASE, python_pip_executable)
+    PEXPECT_ERRORMESSAGE = "{}, try: {} install pexpect".format(PEXPECT_ERRORMESSAGE_BASE, python_pip_executable)
+    CREDSSP_ERRORMESSAGE = "{}, try: {} install pywinrm[credssp]".format(CREDSSP_ERRORMESSAGE_BASE, python_pip_executable)
+    NTLM_ERRORMESSAGE = "{}, try: {} install requests-ntlm".format(NTLM_ERRORMESSAGE_BASE, python_pip_executable)
+
+
 if enabledHttpDebug:
     httpclient_logging_patch(logging.DEBUG)
 
+PACKAGE_ERROR = False
+
 if not URLLIB_INSTALLED:
-    log.error("request and urllib3 not installed, try: pip install requests &&  pip install urllib3")
-    sys.exit(1)
+    log.error(URLLIB_ERRORMESSAGE)
+    PACKAGE_ERROR = True
 
 if not WINRM_INSTALLED:
-    log.error("winrm not installed, try: pip install pywinrm")
-    sys.exit(1)
+    log.error(WINRM_ERRORMESSAGE)
+    PACKAGE_ERROR = True
 
 if authentication == "kerberos" and not KRB_INSTALLED:
-    log.error("Kerberos not installed, try: pip install requests-kerberos")
-    sys.exit(1)
+    log.error(KRB_ERRORMESSAGE)
+    PACKAGE_ERROR = True
 
 if authentication == "kerberos" and not HAS_PEXPECT:
-    log.error("pexpect not installed, try: pip install pexpect")
-    sys.exit(1)
+    log.error(PEXPECT_ERRORMESSAGE)
+    PACKAGE_ERROR = True
 
 if authentication == "credssp" and not HAS_CREDSSP:
-    log.error("CredSSP not installed, try: pip install pywinrm[credssp]")
-    sys.exit(1)
+    log.error(CREDSSP_ERRORMESSAGE)
+    PACKAGE_ERROR = True
 
 if authentication == "ntlm" and not HAS_NTLM:
-    log.error("NTLM not installed, try: pip install requests_ntlm")
+    log.error(NTLM_ERRORMESSAGE)
+    PACKAGE_ERROR = True
+
+if PACKAGE_ERROR:
     sys.exit(1)
 
 arguments = {}

--- a/contents/winrm-exec.py
+++ b/contents/winrm-exec.py
@@ -1,7 +1,7 @@
 import argparse
 try:
 	import os; os.environ['PATH']
-except:
+except Exception:
 	import os
 	os.environ.setdefault('PATH', '')
 import sys
@@ -22,7 +22,7 @@ class SuppressFilter(logging.Filter):
 try:
     from urllib3.connectionpool import log
     #log.addFilter(SuppressFilter())
-except:
+except ImportError:
     pass
 
 import http.client
@@ -99,7 +99,11 @@ except ImportError as e:
 try:
     externally_managed_path = os.path.join(sysconfig.get_path("stdlib"), "EXTERNALLY-MANAGED")
     SYSTEM_INTERPRETER = os.path.exists(externally_managed_path)
-except:
+except Exception:
+    logging.getLogger(__name__).debug(
+        "Failed to detect externally-managed Python environment; assuming non-system interpreter",
+        exc_info=True,
+    )
     SYSTEM_INTERPRETER = False
 
 if os.environ.get('RD_JOB_LOGLEVEL') == 'DEBUG':
@@ -289,8 +293,31 @@ NTLM_ERRORMESSAGE_BASE = "requests-ntlm not installed"
 if SYSTEM_INTERPRETER:
     import configparser
     externally_managed_file = configparser.RawConfigParser()
-    externally_managed_file.read(externally_managed_path)
-    SYSTEM_INTERPRETER_ERRORMESSAGE=externally_managed_file.get("externally-managed", "Error")
+    SYSTEM_INTERPRETER_ERRORMESSAGE = ""
+    try:
+        # Attempt to read the EXTERNALLY-MANAGED file and extract the error message.
+        externally_managed_file.read(externally_managed_path)
+        SYSTEM_INTERPRETER_ERRORMESSAGE = externally_managed_file.get(
+            "externally-managed",
+            "Error",
+            fallback=""
+        )
+    except (configparser.NoSectionError,
+            configparser.NoOptionError,
+            configparser.MissingSectionHeaderError,
+            configparser.ParsingError,
+            OSError):
+        # If the file is missing, malformed, or does not have the expected
+        # section/key, fall back to a generic message instead of crashing.
+        SYSTEM_INTERPRETER_ERRORMESSAGE = ""
+
+    if not SYSTEM_INTERPRETER_ERRORMESSAGE:
+        SYSTEM_INTERPRETER_ERRORMESSAGE = (
+            "Python packages are externally managed by your system. "
+            "Please refer to your operating system's package manager "
+            "documentation for instructions on installing additional "
+            "Python packages when using the system interpreter."
+        )
 
     ERRORMESSAGE = ", please install it using your systems package manager or consider using a virtual environment.\n{}".format(SYSTEM_INTERPRETER_ERRORMESSAGE)
     URLLIB_ERRORMESSAGE = "{}{}".format(URLLIB_ERRORMESSAGE_BASE, ERRORMESSAGE)

--- a/contents/winrm-filecopier.py
+++ b/contents/winrm-filecopier.py
@@ -17,8 +17,10 @@ from colored_formatter import ColoredFormatter
 import kerberosauth
 import http.client
 import winrm_session
+import sysconfig
+import os.path
 
-# checking and importing dependencies
+#checking and importing dependencies
 ISPY3 = sys.version_info[0] == 3
 WINRM_INSTALLED = False
 URLLIB_INSTALLED = False
@@ -26,6 +28,7 @@ KRB_INSTALLED = False
 HAS_NTLM = False
 HAS_CREDSSP = False
 HAS_PEXPECT = False
+SYSTEM_INTERPRETER = False
 
 if ISPY3:
     from inspect import getfullargspec as getargspec
@@ -76,6 +79,12 @@ try:
             HAS_PEXPECT = True
 except ImportError as e:
     HAS_PEXPECT = False
+
+try:
+    externally_managed_path = os.path.join(sysconfig.get_path("stdlib"), "EXTERNALLY-MANAGED")
+    SYSTEM_INTERPRETER = os.path.exists(externally_managed_path)
+except:
+    SYSTEM_INTERPRETER = False
 
 log_level = 'INFO'
 if os.environ.get('RD_JOB_LOGLEVEL') == 'DEBUG':
@@ -376,28 +385,67 @@ if(readtimeout):
 if(operationtimeout):
     arguments["operation_timeout_sec"] = operationtimeout
 
+URLLIB_ERRORMESSAGE_BASE = "requests and urllib3 not installed"
+WINRM_ERRORMESSAGE_BASE = "pywinrm not installed"
+KRB_ERRORMESSAGE_BASE = "requests-kerberos not installed"
+PEXPECT_ERRORMESSAGE_BASE = "pexpect not installed"
+CREDSSP_ERRORMESSAGE_BASE = "pywinrm[credssp] not installed"
+NTLM_ERRORMESSAGE_BASE = "requests-ntlm not installed"
+
+if SYSTEM_INTERPRETER:
+    import configparser
+    externally_managed_file = configparser.RawConfigParser()
+    externally_managed_file.read(externally_managed_path)
+    SYSTEM_INTERPRETER_ERRORMESSAGE=externally_managed_file.get("externally-managed", "Error")
+
+    ERRORMESSAGE = ", please install it using your systems package manager or consider using a virtual environment.\n{}".format(SYSTEM_INTERPRETER_ERRORMESSAGE)
+    URLLIB_ERRORMESSAGE = "{}{}".format(URLLIB_ERRORMESSAGE_BASE, ERRORMESSAGE)
+    WINRM_ERRORMESSAGE = "{}{}".format(WINRM_ERRORMESSAGE_BASE, ERRORMESSAGE)
+    KRB_ERRORMESSAGE = "{}{}".format(KRB_ERRORMESSAGE_BASE, ERRORMESSAGE)
+    PEXPECT_ERRORMESSAGE = "{}{}".format(PEXPECT_ERRORMESSAGE_BASE, ERRORMESSAGE)
+    CREDSSP_ERRORMESSAGE = "{}{}".format(CREDSSP_ERRORMESSAGE_BASE, ERRORMESSAGE)
+    NTLM_ERRORMESSAGE = "{}{}".format(NTLM_ERRORMESSAGE_BASE, ERRORMESSAGE)
+else:
+    python_executable_basename = os.path.dirname(sys.executable)
+    python_pip_executable = os.path.join(python_executable_basename, "pip3" if ISPY3 else "pip")
+    URLLIB_ERRORMESSAGE = "{}, try: {} install requests urllib3".format(URLLIB_ERRORMESSAGE_BASE, python_pip_executable)
+    WINRM_ERRORMESSAGE = "{}, try: {} install pywinrm".format(WINRM_ERRORMESSAGE_BASE, python_pip_executable)
+    KRB_ERRORMESSAGE = "{}, try: {} install requests-kerberos".format(KRB_ERRORMESSAGE_BASE, python_pip_executable)
+    PEXPECT_ERRORMESSAGE = "{}, try: {} install pexpect".format(PEXPECT_ERRORMESSAGE_BASE, python_pip_executable)
+    CREDSSP_ERRORMESSAGE = "{}, try: {} install pywinrm[credssp]".format(CREDSSP_ERRORMESSAGE_BASE, python_pip_executable)
+    NTLM_ERRORMESSAGE = "{}, try: {} install requests-ntlm".format(NTLM_ERRORMESSAGE_BASE, python_pip_executable)
+
+
+if enabledHttpDebug:
+    httpclient_logging_patch(logging.DEBUG)
+
+PACKAGE_ERROR = False
+
 if not URLLIB_INSTALLED:
-    log.error("request and urllib3 not installed, try: pip install requests &&  pip install urllib3")
-    sys.exit(1)
+    log.error(URLLIB_ERRORMESSAGE)
+    PACKAGE_ERROR = True
 
 if not WINRM_INSTALLED:
-    log.error("winrm not installed, try: pip install pywinrm")
-    sys.exit(1)
+    log.error(WINRM_ERRORMESSAGE)
+    PACKAGE_ERROR = True
 
 if authentication == "kerberos" and not KRB_INSTALLED:
-    log.error("Kerberos not installed, try: pip install pywinrm[kerberos]")
-    sys.exit(1)
+    log.error(KRB_ERRORMESSAGE)
+    PACKAGE_ERROR = True
 
 if authentication == "kerberos" and not HAS_PEXPECT:
-    log.error("pexpect not installed, try: pip install pexpect")
-    sys.exit(1)
+    log.error(PEXPECT_ERRORMESSAGE)
+    PACKAGE_ERROR = True
 
 if authentication == "credssp" and not HAS_CREDSSP:
-    log.error("CredSSP not installed, try: pip install pywinrm[credssp]")
-    sys.exit(1)
+    log.error(CREDSSP_ERRORMESSAGE)
+    PACKAGE_ERROR = True
 
 if authentication == "ntlm" and not HAS_NTLM:
-    log.error("NTLM not installed, try: pip install requests_ntlm")
+    log.error(NTLM_ERRORMESSAGE)
+    PACKAGE_ERROR = True
+
+if PACKAGE_ERROR:
     sys.exit(1)
 
 if authentication == "kerberos":

--- a/contents/winrm-filecopier.py
+++ b/contents/winrm-filecopier.py
@@ -406,14 +406,12 @@ if SYSTEM_INTERPRETER:
     CREDSSP_ERRORMESSAGE = "{}{}".format(CREDSSP_ERRORMESSAGE_BASE, ERRORMESSAGE)
     NTLM_ERRORMESSAGE = "{}{}".format(NTLM_ERRORMESSAGE_BASE, ERRORMESSAGE)
 else:
-    python_executable_basename = os.path.dirname(sys.executable)
-    python_pip_executable = os.path.join(python_executable_basename, "pip3" if ISPY3 else "pip")
-    URLLIB_ERRORMESSAGE = "{}, try: {} install requests urllib3".format(URLLIB_ERRORMESSAGE_BASE, python_pip_executable)
-    WINRM_ERRORMESSAGE = "{}, try: {} install pywinrm".format(WINRM_ERRORMESSAGE_BASE, python_pip_executable)
-    KRB_ERRORMESSAGE = "{}, try: {} install requests-kerberos".format(KRB_ERRORMESSAGE_BASE, python_pip_executable)
-    PEXPECT_ERRORMESSAGE = "{}, try: {} install pexpect".format(PEXPECT_ERRORMESSAGE_BASE, python_pip_executable)
-    CREDSSP_ERRORMESSAGE = "{}, try: {} install pywinrm[credssp]".format(CREDSSP_ERRORMESSAGE_BASE, python_pip_executable)
-    NTLM_ERRORMESSAGE = "{}, try: {} install requests-ntlm".format(NTLM_ERRORMESSAGE_BASE, python_pip_executable)
+    URLLIB_ERRORMESSAGE = "{}, try: {} -m pip install requests urllib3".format(URLLIB_ERRORMESSAGE_BASE, sys.executable)
+    WINRM_ERRORMESSAGE = "{}, try: {} -m pip install pywinrm".format(WINRM_ERRORMESSAGE_BASE, sys.executable)
+    KRB_ERRORMESSAGE = "{}, try: {} -m pip install requests-kerberos".format(KRB_ERRORMESSAGE_BASE, sys.executable)
+    PEXPECT_ERRORMESSAGE = "{}, try: {} -m pip install pexpect".format(PEXPECT_ERRORMESSAGE_BASE, sys.executable)
+    CREDSSP_ERRORMESSAGE = "{}, try: {} -m pip install pywinrm[credssp]".format(CREDSSP_ERRORMESSAGE_BASE, sys.executable)
+    NTLM_ERRORMESSAGE = "{}, try: {} -m pip install requests-ntlm".format(NTLM_ERRORMESSAGE_BASE, sys.executable)
 
 
 if enabledHttpDebug:

--- a/contents/winrm-filecopier.py
+++ b/contents/winrm-filecopier.py
@@ -3,7 +3,6 @@ try:
 except:
 	import os
 	os.environ.setdefault('PATH', '')
-import winrm
 import argparse
 import sys
 import base64
@@ -83,7 +82,13 @@ except ImportError as e:
 try:
     externally_managed_path = os.path.join(sysconfig.get_path("stdlib"), "EXTERNALLY-MANAGED")
     SYSTEM_INTERPRETER = os.path.exists(externally_managed_path)
-except:
+except Exception as e:
+    logger = logging.getLogger(__name__)
+    logger.debug(
+        "Failed to detect externally-managed system interpreter using path %r: %s",
+        externally_managed_path if 'externally_managed_path' in locals() else None,
+        e,
+    )
     SYSTEM_INTERPRETER = False
 
 log_level = 'INFO'
@@ -396,7 +401,10 @@ if SYSTEM_INTERPRETER:
     import configparser
     externally_managed_file = configparser.RawConfigParser()
     externally_managed_file.read(externally_managed_path)
-    SYSTEM_INTERPRETER_ERRORMESSAGE=externally_managed_file.get("externally-managed", "Error")
+    try:
+        SYSTEM_INTERPRETER_ERRORMESSAGE = externally_managed_file.get("externally-managed", "Error")
+    except (configparser.NoSectionError, configparser.NoOptionError):
+        SYSTEM_INTERPRETER_ERRORMESSAGE = "Python on this system is externally managed by your operating system or distribution. Please use your system package manager to install additional Python packages, or consider using a virtual environment."
 
     ERRORMESSAGE = ", please install it using your systems package manager or consider using a virtual environment.\n{}".format(SYSTEM_INTERPRETER_ERRORMESSAGE)
     URLLIB_ERRORMESSAGE = "{}{}".format(URLLIB_ERRORMESSAGE_BASE, ERRORMESSAGE)
@@ -412,10 +420,6 @@ else:
     PEXPECT_ERRORMESSAGE = "{}, try: {} -m pip install pexpect".format(PEXPECT_ERRORMESSAGE_BASE, sys.executable)
     CREDSSP_ERRORMESSAGE = "{}, try: {} -m pip install pywinrm[credssp]".format(CREDSSP_ERRORMESSAGE_BASE, sys.executable)
     NTLM_ERRORMESSAGE = "{}, try: {} -m pip install requests-ntlm".format(NTLM_ERRORMESSAGE_BASE, sys.executable)
-
-
-if enabledHttpDebug:
-    httpclient_logging_patch(logging.DEBUG)
 
 PACKAGE_ERROR = False
 

--- a/plugin.yaml
+++ b/plugin.yaml
@@ -25,8 +25,7 @@ providers:
       - name: interpreter
         title: Python Interpreter
         description: "Python Interpreter (Default: python)"
-        type: Select
-        values: "python,python2,python3"
+        type: String
         default: "python"
         required: true
         scope: Instance

--- a/plugin.yaml
+++ b/plugin.yaml
@@ -233,8 +233,7 @@ providers:
       - name: interpreter
         title: Python Interpreter
         description: "Python Interpreter (Default: python)"
-        type: Select
-        values: "python,python2,python3"
+        type: String
         default: "python"
         required: true
         scope: Instance
@@ -421,8 +420,7 @@ providers:
       - name: interpreter
         title: Python Interpreter
         description: "Python Interpreter (Default: python)"
-        type: Select
-        values: "python,python2,python3"
+        type: String
         default: "python"
         required: true
         scope: Instance


### PR DESCRIPTION
Ubuntu 24.04 and other distros are implementing the Externally Managed Environments spec to prevent the system interpreter from becoming contaminated. This means that most projects should use a virtual environment or restrict themselves to the python packages that are available from the distributions package manager.

This MR implements specifying an arbitrary path to a python interpreter to use when running this plugin as well as expanding the error messages that are printed when a module is missing.

Closes #105

---

**Maintainer notes:**
- Merged current `main` into this branch and resolved 3 conflicts (all additive, not competing changes): `plugin.yaml`'s `interpreter` config kept as free-text but with main's `python3` default, main's new proxy/no-proxy config block was carried forward, and `contents/winrm-check.py`'s imports were combined.
- Verified locally (CI does not run on this PR): `./gradlew build` passes, all Python files parse cleanly, and the full unit test suite (26 tests) passes.
- All prior Copilot review comments on this PR (bare `except:` clauses, unguarded `configparser` reads, unconditional `import winrm`, duplicate debug-patch call, inconsistent config type across providers) were already addressed in earlier commits — reverified against the merged code.
