### PR TITLE
Update upload-artifact action to v4

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -25,7 +25,7 @@ jobs:
       id: get_version
       run: VERSION=$(./gradlew currentVersion -q -Prelease.quiet) && echo ::set-output name=VERSION::$VERSION
     - name: Upload py-winrm-plugin zip
-      uses: actions/upload-artifact@v1.0.0
+      uses: actions/upload-artifact@v4
       with:
         # Artifact name
         name: py-winrm-plugin-${{ steps.get_version.outputs.VERSION }}


### PR DESCRIPTION
## Summary
- Updates `actions/upload-artifact` from v1.0.0 to v4 in the build workflow

## Test plan
- [ ] Verify GitHub Actions workflow runs successfully
- [ ] Confirm artifact is uploaded correctly with v4

🤖 Generated with [Claude Code](https://claude.com/claude-code)