### PR TITLE
Add NO_PROXY support for automatic proxy bypass based on target host

### DIFF
--- a/contents/common.py
+++ b/contents/common.py
@@ -67,8 +67,35 @@ def conditionalReplace( aMatch ) :
     return result+' '
 
 
+def _redact_proxy_url(url):
+    """Redact userinfo from proxy URL for safe logging."""
+    if not url:
+        return url
+    try:
+        try:
+            from urllib.parse import urlparse, urlunparse
+        except ImportError:
+            from urlparse import urlparse, urlunparse
+        parsed = urlparse(url)
+        if parsed.username or parsed.password:
+            netloc = parsed.hostname or ''
+            if parsed.port:
+                netloc += ':%s' % parsed.port
+            return urlunparse(parsed._replace(netloc=netloc))
+    except Exception:
+        return '[REDACTED]'
+    return url
+
+
 def configure_proxy(arguments, winrmproxy, winrmnoproxy, endpoint, log):
-    from requests.utils import should_bypass_proxies
+    try:
+        from requests.utils import should_bypass_proxies
+    except (ImportError, AttributeError):
+        log.warning("requests.utils.should_bypass_proxies not available; NO_PROXY requires requests >= 2.14.0")
+        if winrmproxy:
+            arguments["proxy"] = winrmproxy
+            log.info("Connecting to %s via PROXY (%s)" % (endpoint, _redact_proxy_url(winrmproxy)))
+        return arguments
 
     if winrmproxy:
         if winrmnoproxy:
@@ -76,16 +103,16 @@ def configure_proxy(arguments, winrmproxy, winrmnoproxy, endpoint, log):
             os.environ['HTTP_PROXY'] = winrmproxy
             os.environ['HTTPS_PROXY'] = winrmproxy
             os.environ['NO_PROXY'] = winrmnoproxy
-            log.debug("Proxy via env vars: HTTP(S)_PROXY=%s, NO_PROXY=%s" % (winrmproxy, winrmnoproxy))
+            log.debug("Proxy via env vars: HTTP(S)_PROXY set, NO_PROXY=%s" % winrmnoproxy)
 
             if should_bypass_proxies(endpoint, no_proxy=winrmnoproxy):
                 log.info("Connecting to %s DIRECTLY (matched NO_PROXY: %s)" % (endpoint, winrmnoproxy))
             else:
-                log.info("Connecting to %s via PROXY (%s)" % (endpoint, winrmproxy))
+                log.info("Connecting to %s via PROXY (%s)" % (endpoint, _redact_proxy_url(winrmproxy)))
         else:
             # Legacy: explicit proxy for all connections
             arguments["proxy"] = winrmproxy
-            log.info("Connecting to %s via PROXY (%s)" % (endpoint, winrmproxy))
+            log.info("Connecting to %s via PROXY (%s)" % (endpoint, _redact_proxy_url(winrmproxy)))
     else:
         if winrmnoproxy:
             log.warning("noproxy is set but no proxy configured; noproxy ignored")

--- a/contents/common.py
+++ b/contents/common.py
@@ -1,4 +1,5 @@
 import re
+import os
 
 
 def check_is_file(destination):
@@ -64,3 +65,29 @@ def conditionalReplace( aMatch ) :
         result = '"' + result + '"'
 
     return result+' '
+
+
+def configure_proxy(arguments, winrmproxy, winrmnoproxy, endpoint, log):
+    from requests.utils import should_bypass_proxies
+
+    if winrmproxy:
+        if winrmnoproxy:
+            # Delegate to requests via env vars so NO_PROXY matching works
+            os.environ['HTTP_PROXY'] = winrmproxy
+            os.environ['HTTPS_PROXY'] = winrmproxy
+            os.environ['NO_PROXY'] = winrmnoproxy
+            log.debug("Proxy via env vars: HTTP(S)_PROXY=%s, NO_PROXY=%s" % (winrmproxy, winrmnoproxy))
+
+            if should_bypass_proxies(endpoint, no_proxy=winrmnoproxy):
+                log.info("Connecting to %s DIRECTLY (matched NO_PROXY: %s)" % (endpoint, winrmnoproxy))
+            else:
+                log.info("Connecting to %s via PROXY (%s)" % (endpoint, winrmproxy))
+        else:
+            # Legacy: explicit proxy for all connections
+            arguments["proxy"] = winrmproxy
+            log.info("Connecting to %s via PROXY (%s)" % (endpoint, winrmproxy))
+    else:
+        if winrmnoproxy:
+            log.warning("noproxy is set but no proxy configured; noproxy ignored")
+        log.info("Connecting to %s DIRECTLY (no proxy configured)" % endpoint)
+    return arguments

--- a/contents/winrm-check.py
+++ b/contents/winrm-check.py
@@ -9,6 +9,7 @@ import logging
 import colored_formatter
 from colored_formatter import ColoredFormatter
 import kerberosauth
+import common
 
 
 #checking and importing dependencies
@@ -105,6 +106,8 @@ parser.add_argument('--diabletls12', help='diabletls12',default="False")
 parser.add_argument('--debug', help='debug',default="False")
 parser.add_argument('--certpath', help='certpath')
 parser.add_argument('--krb5config', help='krb5config',default="/etc/krb5.conf")
+parser.add_argument('--proxy', help='proxy', default=None)
+parser.add_argument('--noproxy', help='noproxy patterns', default=None)
 
 
 args = parser.parse_args()
@@ -160,6 +163,13 @@ if args.debug:
 
 if args.certpath:
     certpath = args.certpath
+
+winrmproxy = None
+winrmnoproxy = None
+if args.proxy and args.proxy not in ("None", ""):
+    winrmproxy = args.proxy
+if args.noproxy and args.noproxy not in ("None", ""):
+    winrmnoproxy = args.noproxy
 
 if not hostname:
     print("hostname is required")
@@ -242,6 +252,8 @@ else:
         arguments["ca_trust_path"] = certpath
 
 arguments["credssp_disable_tlsv1_2"] = diabletls12
+
+common.configure_proxy(arguments, winrmproxy, winrmnoproxy, endpoint, log)
 
 if authentication == "kerberos":
     k5bConfig = kerberosauth.KerberosAuth(krb5config=krb5config, log=log, kinit_command=kinit,username=username, password=password)

--- a/contents/winrm-exec.py
+++ b/contents/winrm-exec.py
@@ -139,6 +139,7 @@ retryconnection = 1
 retryconnectiondelay = 0
 username = None
 winrmproxy = None
+winrmnoproxy = None
 
 if "RD_CONFIG_AUTHTYPE" in os.environ:
     authentication = os.getenv("RD_CONFIG_AUTHTYPE")
@@ -188,6 +189,10 @@ if "RD_CONFIG_CLEANESCAPING" in os.environ:
 if "RD_CONFIG_WINRMPROXY" in os.environ:
     winrmproxy = os.getenv("RD_CONFIG_WINRMPROXY")
     log.debug("winrmproxy: " + str(winrmproxy))
+
+if "RD_CONFIG_WINRMNOPROXY" in os.environ:
+    winrmnoproxy = os.getenv("RD_CONFIG_WINRMNOPROXY")
+    log.debug("winrmnoproxy: " + str(winrmnoproxy))
 
 if "RD_CONFIG_ENABLEDHTTPDEBUG" in os.environ:
     if os.getenv("RD_CONFIG_ENABLEDHTTPDEBUG") == "true":
@@ -311,8 +316,7 @@ else:
 if(readtimeout):
     arguments["read_timeout_sec"] = readtimeout
 
-if(winrmproxy):
-    arguments["proxy"] = winrmproxy
+common.configure_proxy(arguments, winrmproxy, winrmnoproxy, endpoint, log)
 
 if(operationtimeout):
     arguments["operation_timeout_sec"] = operationtimeout

--- a/contents/winrm-filecopier.py
+++ b/contents/winrm-filecopier.py
@@ -268,6 +268,7 @@ retryconnectiondelay = 0
 certpath = None
 username = None
 winrmproxy = None
+winrmnoproxy = None
 
 if os.environ.get('RD_CONFIG_OVERRIDE') == 'true':
     override = True
@@ -298,6 +299,9 @@ if "RD_CONFIG_CERTPATH" in os.environ:
 
 if "RD_CONFIG_WINRMPROXY" in os.environ:
     winrmproxy = os.getenv("RD_CONFIG_WINRMPROXY")
+
+if "RD_CONFIG_WINRMNOPROXY" in os.environ:
+    winrmnoproxy = os.getenv("RD_CONFIG_WINRMNOPROXY")
 
 if "RD_OPTION_USERNAME" in os.environ and os.getenv("RD_OPTION_USERNAME"):
     #take user from job
@@ -367,8 +371,7 @@ else:
 
 arguments["credssp_disable_tlsv1_2"] = diabletls12
 
-if(winrmproxy):
-    arguments["proxy"] = winrmproxy
+common.configure_proxy(arguments, winrmproxy, winrmnoproxy, endpoint, log)
 
 if(readtimeout):
     arguments["read_timeout_sec"] = readtimeout

--- a/plugin.yaml
+++ b/plugin.yaml
@@ -110,6 +110,15 @@ providers:
         renderingOptions:
           groupName: Connection
           instance-scope-node-attribute: "winrm-proxy"
+      - name: winrmnoproxy
+        title: No Proxy List
+        description: "Comma-separated list of hosts/IPs/CIDRs that bypass the proxy. Supports exact IPs, CIDR notation (192.168.1.0/24), domain suffixes (.internal.corp), and wildcard (*). Requires Proxy to also be set. It can be overwriting at node level using `winrm-noproxy`"
+        type: String
+        required: false
+        scope: Instance
+        renderingOptions:
+          groupName: Connection
+          instance-scope-node-attribute: "winrm-noproxy"
       - name: operationtimeout
         title: operation timeout
         description: "maximum allowed time in seconds for any single wsman HTTP operation (default 20). Note that operation timeouts while receiving output (the only wsman operation that should take any significant time, and where these timeouts are expected) will be silently retried indefinitely. It can be overwriting at node level using `winrm-operationtimeout`"
@@ -380,6 +389,15 @@ providers:
         renderingOptions:
           groupName: Connection
           instance-scope-node-attribute: "winrm-proxy"
+      - name: winrmnoproxy
+        title: No Proxy List
+        description: "Comma-separated list of hosts/IPs/CIDRs that bypass the proxy. Supports exact IPs, CIDR notation (192.168.1.0/24), domain suffixes (.internal.corp), and wildcard (*). Requires Proxy to also be set. It can be overwriting at node level using `winrm-noproxy`"
+        type: String
+        required: false
+        scope: Instance
+        renderingOptions:
+          groupName: Connection
+          instance-scope-node-attribute: "winrm-noproxy"
       - name: enabledhttpdebug
         title: Enable HTTP logging in debug mode
         description: "Print extra http logging in debug mode"
@@ -417,7 +435,7 @@ providers:
     plugin-type: script
     script-interpreter: ${config.interpreter} -u
     script-file: winrm-check.py
-    script-args: --username ${config.username} --hostname ${config.hostname} --password ${config.password_storage_path} --authentication ${config.authtype} --transport ${config.winrmtransport} --port ${config.winrmport} --nossl ${config.nossl} --debug ${config.debug} --certpath ${config.certpath}
+    script-args: --username ${config.username} --hostname ${config.hostname} --password ${config.password_storage_path} --authentication ${config.authtype} --transport ${config.winrmtransport} --port ${config.winrmport} --nossl ${config.nossl} --debug ${config.debug} --certpath ${config.certpath} --proxy ${config.winrmproxy} --noproxy ${config.winrmnoproxy}
     config:
       - name: interpreter
         title: Python Interpreter
@@ -513,3 +531,13 @@ providers:
         required: false
         renderingOptions:
           groupName: Kerberos
+      - name: winrmproxy
+        title: Proxy
+        description: "Specify a proxy address for communicating with Windows nodes. Example HTTP proxy strings are http://server:port and http://user:pass@server:port. An example SOCKS5 proxy string is socks5://user:pass@server:port."
+        type: String
+        required: false
+      - name: winrmnoproxy
+        title: No Proxy List
+        description: "Comma-separated list of hosts/IPs/CIDRs that bypass the proxy. Supports exact IPs, CIDR notation (192.168.1.0/24), domain suffixes (.internal.corp), and wildcard (*)."
+        type: String
+        required: false


### PR DESCRIPTION
VIDEO TESTING:

https://github.com/user-attachments/assets/c0ff659b-aa68-400e-9350-828e31ac10c0




## Summary

- Add a new **No Proxy List** configuration parameter to all three plugin providers (NodeExecutor, FileCopier, WinRMCheck) that allows specifying hosts/IPs/CIDRs that should bypass the proxy and connect directly
- Centralize proxy logic in a new `configure_proxy()` function in `common.py` that delegates proxy routing to Python's `requests` library via environment variables (`HTTP_PROXY`, `HTTPS_PROXY`, `NO_PROXY`), enabling automatic per-host proxy decisions
- Add clear INFO-level log messages indicating the connection path for each execution (`DIRECTLY` vs `via PROXY`), so operators can verify routing without enabling debug mode
- Maintain full backward compatibility: when only Proxy is set (no No Proxy List), the existing explicit proxy behavior is preserved

## Changed files

| File | Changes |
|---|---|
| `contents/common.py` | Added `configure_proxy()` function with env-var delegation, `should_bypass_proxies` check, and INFO-level logging |
| `contents/winrm-exec.py` | Read `RD_CONFIG_WINRMNOPROXY` env var, replaced explicit proxy assignment with `configure_proxy()` call |
| `contents/winrm-filecopier.py` | Same pattern as winrm-exec.py |
| `contents/winrm-check.py` | Added `--proxy` and `--noproxy` argparse arguments, added `import common`, integrated `configure_proxy()` call |
| `plugin.yaml` | Added `winrmnoproxy` property to WinRMPython and WinRMcpPython providers; added `winrmproxy` and `winrmnoproxy` to WinRMCheck provider; updated WinRMCheck `script-args` |

## How it works

When both **Proxy** and **No Proxy List** are configured:
1. The plugin sets `HTTP_PROXY`, `HTTPS_PROXY`, and `NO_PROXY` environment variables instead of passing `proxy=` directly to `winrm.Session()`
2. Python's `requests` library (used internally by pywinrm) natively evaluates the target host against `NO_PROXY` patterns
3. If the target matches `NO_PROXY`, the connection goes direct; otherwise it routes through the proxy

When only **Proxy** is configured (no No Proxy List):
- Legacy behavior is preserved: proxy is passed explicitly to `winrm.Session()` for all connections

## Supported NO_PROXY patterns

- Exact IP: `192.168.1.50`
- CIDR notation: `192.168.1.0/24`, `10.0.0.0/8`
- Domain suffix: `.internal.corp`
- Exact hostname: `myserver.domain.com`
- Wildcard (bypass all): `*`
- Multiple values (comma-separated): `192.168.1.0/24,10.0.0.0/8,.internal.corp`

## Log output examples

**Target matches NO_PROXY (direct connection):**
```
[INFO] Connecting to http://10.0.0.100:5985 DIRECTLY (matched NO_PROXY: 10.0.0.0/24)
```

**Target does NOT match NO_PROXY (proxy connection):**
```
[INFO] Connecting to http://10.0.0.100:5985 via PROXY (http://proxy-server:8080)
```

## Testing

- ✅ Proxy + No Proxy List matching target IP → connection goes DIRECTLY (bypasses proxy)
- ✅ Proxy + No Proxy List NOT matching target IP → connection routes via PROXY
- ✅ INFO-level log messages correctly indicate routing decision
- ✅ Verified with Rundeck WAR environment on macOS


