### PR TITLE
[RUN-3009] implements kill on abort

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,5 +21,11 @@ gradle-app.setting
 
 # End of https://www.gitignore.io/api/java,gradle
 
+### Python ###
+__pycache__/
+*.py[cod]
+*.egg-info/
+.pytest_cache/
+
 # Local build logs
 .temp

--- a/README.md
+++ b/README.md
@@ -41,6 +41,7 @@ It can be overwriting at node level using `winrm-operationtimeout`
   It can be overwriting at node level using `winrm-retry-connection`
 * **retry connection**: Delay between retries in seconds (default 10 seconds).
   It can be overwriting at node level using `winrm-retry-connection-delay`
+* **Terminate On Abort**: When enabled, aborting a job terminates the remote command **and its whole process tree** on the Windows node. Disabled by default (legacy behaviour). It can be overwritten at node level using `winrm-terminate-on-abort`. See [Aborting jobs](#aborting-jobs).
 
 For Kerberos
 * **krb5 Config File**: path of the krb5.conf (default: /etc/krb5.conf)
@@ -175,6 +176,37 @@ catch {
     exit 1
 }
 ```
+
+## Aborting jobs
+
+When a job step runs on a Windows node over WinRM, the command (and any child
+processes it spawns) runs on the remote node, while only a thin client process
+runs on the Rundeck server/runner. Historically, aborting the job killed the
+local client but left the remote command — and especially the child processes it
+had spawned — running on the Windows node.
+
+The **Terminate On Abort** option fixes this. It is **disabled by default**;
+enable the checkbox (or set node attribute `winrm-terminate-on-abort=true`) to
+turn it on. When enabled:
+
+1. Before launching, the plugin prepends a tiny preamble that makes the remote
+   shell report the root PID of its process tree. The marker line is parsed by
+   the plugin and removed from the job output, so it is not visible in the log.
+   - For the `powershell` shell this uses the built-in `$PID` variable.
+   - For the `cmd` shell the PID of the `cmd.exe` process is resolved via a
+     short-lived child PowerShell (no dependency on the deprecated `wmic`).
+2. When the job is aborted, the plugin:
+   - sends the WS-Man `terminate` signal to the running command, and
+   - opens a fresh WinRM shell and runs `taskkill /F /T /PID <pid>` to kill the
+     entire process tree on the node.
+
+Notes:
+
+* The `powershell` shell (the default) provides the most reliable PID capture.
+* If no PID could be captured, only the WS-Man `terminate` signal is sent, and
+  some child processes may survive — the behaviour then matches older versions.
+* When the option is disabled (the default), the preamble/termination is skipped
+  entirely and the plugin behaves exactly as older versions did on abort.
 
 ## Troubleshooting
 

--- a/contents/common.py
+++ b/contents/common.py
@@ -33,19 +33,19 @@ def removeSimpleQuotes(command):
 
 def isAPathThatRequiresDoubleQuotes(candidate):
     #first check that this is not multiple paths, e.g. 'C:\windows C:\tmp...'
-    regexpMultipleAbsolutePath = re.compile('\'[a-zA-Z]:\\\\.*\s[a-zA-Z]:\\\\.*') #at least two absolute paths
+    regexpMultipleAbsolutePath = re.compile(r"'[a-zA-Z]:\\.*\s[a-zA-Z]:\\.*") #at least two absolute paths
     if regexpMultipleAbsolutePath.match(candidate): return False
 
     #verify if this is a path with no options after, windows style. e.g. 'C:\Windows /w...'
-    regexpPathAndOption = re.compile('\'[a-zA-Z]:\\\\.*\s/.+')
+    regexpPathAndOption = re.compile(r"'[a-zA-Z]:\\.*\s/.+")
     if regexpPathAndOption.match(candidate): return False
 
     #verify if this is a path with no options after, unix style. e.g. 'C:\Windows -v'
-    regexpPathAndOptionUnix = re.compile('\'[a-zA-Z]:\\\\.*\s-.+')
+    regexpPathAndOptionUnix = re.compile(r"'[a-zA-Z]:\\.*\s-.+")
     if regexpPathAndOptionUnix.match(candidate): return False
 
     #finally, check if this is a single path, with single quotes, and requires to be put between double quotes.e.g. 'C:\Program Files'
-    regexPathRequireQuotes = re.compile('\'[a-zA-Z]:\\\\.*\s')
+    regexPathRequireQuotes = re.compile(r"'[a-zA-Z]:\\.*\s")
     if regexPathRequireQuotes.match(candidate):
         return True
     else:

--- a/contents/winrm-exec.py
+++ b/contents/winrm-exec.py
@@ -382,7 +382,16 @@ lasterrorpos = 0
 
 
 def _emit(raw_text):
-    """Filter out the PID marker, record the PID, and write the rest."""
+    """Write streamed output.
+
+    When Terminate On Abort is disabled the output is written through unchanged
+    (legacy behaviour). When enabled, it is routed through the marker filter to
+    capture the remote PID and hide the marker line; the filter buffers partial
+    lines until a newline, which is only acceptable because the feature is opt-in.
+    """
+    if not terminateonabort:
+        realstdout.write(raw_text)
+        return
     cleaned = marker_filter.feed(raw_text)
     if marker_filter.pid and not tsk.remote_pid:
         tsk.remote_pid = marker_filter.pid
@@ -436,10 +445,11 @@ while True:
         break
 
 # Emit any output still buffered in the marker filter (e.g. a final line with no
-# trailing newline).
-tail = marker_filter.flush()
-if tail:
-    realstdout.write(tail)
+# trailing newline). Only relevant when the filter was actually used.
+if terminateonabort:
+    tail = marker_filter.flush()
+    if tail:
+        realstdout.write(tail)
 
 sys.stdout.seek(0)
 sys.stderr.seek(0)

--- a/contents/winrm-exec.py
+++ b/contents/winrm-exec.py
@@ -6,7 +6,9 @@ except:
 	os.environ.setdefault('PATH', '')
 import sys
 import winrm_session
+import winrm_kill
 import threading
+import signal
 import logging
 import colored_formatter
 import kerberosauth
@@ -140,6 +142,7 @@ retryconnectiondelay = 0
 username = None
 winrmproxy = None
 winrmnoproxy = None
+terminateonabort = False
 
 if "RD_CONFIG_AUTHTYPE" in os.environ:
     authentication = os.getenv("RD_CONFIG_AUTHTYPE")
@@ -206,12 +209,22 @@ if "RD_CONFIG_RETRYCONNECTION" in os.environ:
 if "RD_CONFIG_RETRYCONNECTIONDELAY" in os.environ:
     retryconnectiondelay = int(os.getenv("RD_CONFIG_RETRYCONNECTIONDELAY"))
 
+if "RD_CONFIG_TERMINATEONABORT" in os.environ:
+    terminateonabort = os.getenv("RD_CONFIG_TERMINATEONABORT") == "true"
+
 exec_command = os.getenv("RD_EXEC_COMMAND")
 log.debug("Command will be executed: " + exec_command)
 
 if cleanescapingflg:
      exec_command = common.removeSimpleQuotes(exec_command)
      log.debug("Command escaped will be executed: " + exec_command)
+
+# When abort handling is enabled, prepend a small preamble that makes the remote
+# shell report the root PID of its process tree. This lets us kill the whole tree
+# (including spawned child processes) when the job is aborted (RUN-3009).
+if terminateonabort:
+    exec_command = winrm_kill.wrap_command(exec_command, shell)
+    log.debug("Command wrapped for abort handling")
 
 endpoint=transport+'://'+args.hostname+':'+port
 
@@ -339,29 +352,79 @@ winrm.Session._strip_namespace = winrm_session._strip_namespace
 
 tsk = winrm_session.RunCommand(session, shell, exec_command, retryconnection, retryconnectiondelay, output_charset)
 t = threading.Thread(target=tsk.get_response)
+# Daemonize so the interpreter can exit on abort even while the worker thread is
+# still blocked polling output over WinRM.
+t.daemon = True
 t.start()
 realstdout = sys.stdout
 realstderr = sys.stderr
 sys.stdout = tsk.o_stream
 sys.stderr = tsk.e_stream
 
+# Flag set by the signal handler when Rundeck aborts the job. We only set a flag
+# here and do the actual remote termination from the main loop, to avoid running
+# network I/O inside the signal handler.
+abort_requested = {"flag": False}
+
+
+def _on_abort_signal(signum, frame):
+    abort_requested["flag"] = True
+
+
+if terminateonabort:
+    signal.signal(signal.SIGTERM, _on_abort_signal)
+    signal.signal(signal.SIGINT, _on_abort_signal)
+
+# Captures the remote PID from the streamed output and hides the marker line.
+marker_filter = winrm_kill.MarkerFilter()
 lastpos = 0
 lasterrorpos = 0
 
+
+def _emit(raw_text):
+    """Filter out the PID marker, record the PID, and write the rest."""
+    cleaned = marker_filter.feed(raw_text)
+    if marker_filter.pid and not tsk.remote_pid:
+        tsk.remote_pid = marker_filter.pid
+    if cleaned:
+        realstdout.write(cleaned)
+
+
+def _abort_and_exit():
+    # Flush whatever we already buffered, then terminate the remote tree.
+    try:
+        sys.stdout = realstdout
+        sys.stderr = realstderr
+        tail = marker_filter.flush()
+        if tail:
+            realstdout.write(tail)
+        realstdout.flush()
+    except Exception as e:
+        log.debug("Error flushing output during abort: %s" % e)
+
+    log.warning("Job aborted, terminating remote command on the node...")
+    winrm_kill.terminate_remote(tsk, log)
+    # Force exit: the worker thread may still be blocked on a WinRM receive.
+    os._exit(143)
+
+
 while True:
     t.join(.1)
+
+    if abort_requested["flag"]:
+        _abort_and_exit()
 
     try:
         if sys.stdout.tell() != lastpos:
             sys.stdout.seek(lastpos)
             read=sys.stdout.read()
             if isinstance(read, str):
-                realstdout.write(read)
+                _emit(read)
             else:
-                realstdout.write(read.decode(output_charset))
+                _emit(read.decode(output_charset))
     except UnicodeDecodeError:
         try:
-            realstdout.write(read.decode(DEFAULT_CHARSET))
+            _emit(read.decode(DEFAULT_CHARSET))
         except Exception as e:
             log.error(e)
     except Exception as e:
@@ -371,6 +434,12 @@ while True:
 
     if not t.is_alive():
         break
+
+# Emit any output still buffered in the marker filter (e.g. a final line with no
+# trailing newline).
+tail = marker_filter.flush()
+if tail:
+    realstdout.write(tail)
 
 sys.stdout.seek(0)
 sys.stderr.seek(0)

--- a/contents/winrm_kill.py
+++ b/contents/winrm_kill.py
@@ -1,0 +1,189 @@
+"""Remote process-tree termination support for the WinRM node executor.
+
+When a Rundeck job is aborted, the local ``winrm-exec.py`` process receives a
+termination signal (SIGTERM/SIGINT). By default the Python process simply dies,
+but the command launched over WinRM keeps running on the Windows node together
+with any child processes it spawned (this is the root cause of RUN-3009).
+
+This module provides the building blocks to fix that:
+
+* a small *preamble* that makes the remote shell print its own PID using a
+  recognizable marker line, so we can learn the root PID of the process tree;
+* helpers to parse that PID out of the streamed output and to hide the marker
+  line from the user-visible output;
+* :func:`terminate_remote`, which on abort sends the WS-Man ``terminate`` signal
+  and then force-kills the whole remote process tree with ``taskkill /F /T``.
+
+All of the parsing/wrapping helpers are pure functions so they can be unit
+tested without a live Windows node.
+"""
+
+import re
+import uuid
+
+# Marker emitted by the remote shell so we can capture the root PID of the
+# process tree that WinRM started. Kept intentionally unlikely to collide with
+# real script output.
+PID_MARKER = "RUNDECK:WINRM:REMOTE_PID:"
+
+# Matches a marker line and captures the PID. Tolerates surrounding whitespace
+# and Windows CRLF line endings.
+_PID_CAPTURE_RE = re.compile(
+    r"(?m)^[ \t]*" + re.escape(PID_MARKER) + r"(\d+)[ \t]*\r?$"
+)
+
+# Matches a full marker line including its trailing newline, used to strip the
+# marker from the user-visible output.
+_PID_STRIP_RE = re.compile(
+    r"(?m)^[ \t]*" + re.escape(PID_MARKER) + r"\d+[ \t]*\r?\n?"
+)
+
+
+def build_capture_token(seed=None):
+    """Return a unique token usable to disambiguate the remote shell process."""
+    base = seed if seed else uuid.uuid4().hex
+    return "RD_WINRM_KILLTOKEN_%s" % base
+
+
+def pid_capture_preamble(shell, token=None):
+    """Return a shell snippet that prints the current shell PID as a marker.
+
+    For ``powershell`` this uses the automatic ``$PID`` variable. For ``cmd`` we
+    resolve the PID of the current ``cmd.exe`` by asking a short-lived child
+    PowerShell process for its parent PID (works on all supported Windows
+    versions and does not depend on the deprecated ``wmic`` tool).
+    """
+    if shell == "powershell":
+        return 'Write-Output "%s$PID"; ' % PID_MARKER
+
+    # cmd.exe: a child PowerShell reports our (the parent cmd) PID. Single quotes
+    # are used inside the -Command argument to avoid nested double quotes.
+    # The command is executed via "cmd /c" (a one-liner, not a .bat file), so the
+    # FOR variable uses a single '%'.
+    ps = (
+        "powershell -NoProfile -Command "
+        "\"(Get-CimInstance Win32_Process -Filter ('ProcessId='+$PID))"
+        ".ParentProcessId\""
+    )
+    return (
+        '@for /f "usebackq tokens=*" %i in (`' + ps + '`) do '
+        "@echo " + PID_MARKER + "%i& "
+    )
+
+
+def wrap_command(command, shell, token=None):
+    """Wrap ``command`` so the remote shell reports its PID before running it.
+
+    For ``powershell`` the user script is executed inside a ``& { ... }`` script
+    block so that a leading ``param()`` block in the user script remains valid
+    (PowerShell requires ``param()`` to be the first statement of its block).
+    For ``cmd`` the preamble is simply prepended.
+    """
+    if shell == "powershell":
+        return 'Write-Output "%s$PID"; & {\n%s\n}' % (PID_MARKER, command)
+    return pid_capture_preamble(shell, token) + command
+
+
+def parse_remote_pid(text):
+    """Return the first remote PID found in ``text`` as a string, or ``None``."""
+    if not text:
+        return None
+    match = _PID_CAPTURE_RE.search(text)
+    if match:
+        return match.group(1)
+    return None
+
+
+def strip_pid_marker_lines(text):
+    """Return ``text`` with any PID marker lines removed."""
+    if not text:
+        return text
+    return _PID_STRIP_RE.sub("", text)
+
+
+def build_taskkill_command(pid):
+    """Return the cmd command that force-kills the process tree rooted at pid."""
+    return "taskkill /F /T /PID %s" % pid
+
+
+class MarkerFilter(object):
+    """Streaming filter that captures the remote PID and hides the marker line.
+
+    Output arrives in arbitrary chunks, so a marker line may be split across two
+    reads. The filter buffers the trailing (incomplete) line until a newline is
+    seen, guaranteeing marker lines are processed whole.
+    """
+
+    def __init__(self):
+        self.buffer = ""
+        self.pid = None
+
+    def feed(self, text):
+        """Feed a chunk of decoded output, return text safe to display."""
+        if not text:
+            return ""
+        data = self.buffer + text
+        newline_idx = data.rfind("\n")
+        if newline_idx == -1:
+            # No complete line yet, hold everything back.
+            self.buffer = data
+            return ""
+        complete = data[: newline_idx + 1]
+        self.buffer = data[newline_idx + 1:]
+        return self._process(complete)
+
+    def flush(self):
+        """Return any buffered text (after a final marker check)."""
+        remaining = self._process(self.buffer)
+        self.buffer = ""
+        return remaining
+
+    def _process(self, text):
+        if self.pid is None:
+            found = parse_remote_pid(text)
+            if found:
+                self.pid = found
+        return strip_pid_marker_lines(text)
+
+
+def terminate_remote(tracker, log):
+    """Abort the remote command and kill its whole process tree.
+
+    ``tracker`` is expected to expose ``protocol``, ``shell_id``, ``command_id``,
+    ``session`` and ``remote_pid``. Every step is best-effort: failures are
+    logged but never raised, since this runs while the job is being aborted.
+    """
+    # 1) Ask WinRM to terminate the running command (graceful, unblocks receive).
+    try:
+        if tracker.protocol and tracker.shell_id and tracker.command_id:
+            log.debug("Sending WS-Man terminate signal to the remote command")
+            tracker.protocol.cleanup_command(tracker.shell_id, tracker.command_id)
+    except Exception as e:
+        log.debug("WS-Man terminate signal failed: %s" % e)
+
+    # 2) Force-kill the whole remote process tree from a fresh shell. This is the
+    #    step that actually stops orphaned child processes (RUN-3009).
+    pid = getattr(tracker, "remote_pid", None)
+    if pid:
+        try:
+            kill_cmd = build_taskkill_command(pid)
+            log.warning(
+                "Abort requested: killing remote process tree (PID %s) via taskkill"
+                % pid
+            )
+            result = tracker.session.run_cmd(kill_cmd)
+            log.debug("taskkill result: %s" % getattr(result, "std_out", b""))
+        except Exception as e:
+            log.error("Remote taskkill for PID %s failed: %s" % (pid, e))
+    else:
+        log.warning(
+            "Abort requested but no remote PID was captured; only the WS-Man "
+            "terminate signal was sent. Child processes on the node may survive."
+        )
+
+    # 3) Close the original shell to release server-side resources.
+    try:
+        if tracker.protocol and tracker.shell_id:
+            tracker.protocol.close_shell(tracker.shell_id)
+    except Exception as e:
+        log.debug("close_shell failed: %s" % e)

--- a/contents/winrm_session.py
+++ b/contents/winrm_session.py
@@ -57,7 +57,7 @@ log = logging.getLogger()
 
 # TODO: this PR https://github.com/diyan/pywinrm/pull/55 will add this fix.
 # when this PR is merged, this won't be needed anymore
-def run_cmd(self, command, args=(), out_stream=None, err_stream=None, retry=1, retry_delay=0, output_charset='utf-8'):
+def run_cmd(self, command, args=(), out_stream=None, err_stream=None, retry=1, retry_delay=0, output_charset='utf-8', tracker=None):
     self.protocol.get_command_output = protocol.get_command_output
     winrm.Session._clean_error_msg = self._clean_error_msg
 
@@ -87,7 +87,17 @@ def run_cmd(self, command, args=(), out_stream=None, err_stream=None, retry=1, r
     if shell_id is None:
         raise Exception("Connection failed after {0} retries".format(retry))
 
+    # Expose the live shell/command handles so an abort handler can terminate
+    # the remote process tree (see winrm_kill.terminate_remote).
+    if tracker is not None:
+        tracker.protocol = self.protocol
+        tracker.shell_id = shell_id
+
     command_id = self.protocol.run_command(shell_id, command, args)
+
+    if tracker is not None:
+        tracker.command_id = command_id
+
     rs = Response(self.protocol.get_command_output(self.protocol, shell_id, command_id, out_stream, err_stream))
 
     error = self._clean_error_msg(rs.std_err, output_charset)
@@ -95,10 +105,17 @@ def run_cmd(self, command, args=(), out_stream=None, err_stream=None, retry=1, r
 
     self.protocol.cleanup_command(shell_id, command_id)
     self.protocol.close_shell(shell_id)
+
+    # The shell has been torn down; clear the handles so a late abort does not
+    # try to terminate an already-closed shell.
+    if tracker is not None:
+        tracker.shell_id = None
+        tracker.command_id = None
+
     return rs
 
 
-def run_ps(self, script, out_stream=None, err_stream=None, retry=1, retry_delay=0, output_charset='utf-8'):
+def run_ps(self, script, out_stream=None, err_stream=None, retry=1, retry_delay=0, output_charset='utf-8', tracker=None):
     """base64 encodes a Powershell script and executes the powershell
     encoded script command
     """
@@ -109,7 +126,8 @@ def run_ps(self, script, out_stream=None, err_stream=None, retry=1, retry_delay=
                       err_stream=err_stream,
                       output_charset=output_charset,
                       retry=retry,
-                      retry_delay=retry_delay)
+                      retry_delay=retry_delay,
+                      tracker=tracker)
 
     return rs
 
@@ -180,19 +198,28 @@ class RunCommand:
         self.output_charset = output_charset
         self.retry = retry
         self.retry_delay = retry_delay
+        # Live WinRM handles for the running command, populated by run_cmd so an
+        # abort handler can terminate the remote process tree (RUN-3009).
+        self.protocol = None
+        self.shell_id = None
+        self.command_id = None
+        # Root PID of the remote process tree, captured from the streamed output.
+        self.remote_pid = None
 
     def get_response(self):
         try:
             if self.shell == "cmd":
                 response = self.session.run_cmd(self.exec_command, out_stream=self.o_stream, err_stream=self.e_stream,
-                                                output_charset=self.output_charset, retry=self.retry, retry_delay=self.retry_delay)
+                                                output_charset=self.output_charset, retry=self.retry, retry_delay=self.retry_delay,
+                                                tracker=self)
                 self.o_std = response.std_out
                 self.e_std = response.std_err
                 self.stat = response.status_code
 
             if self.shell == "powershell":
                 response = self.session.run_ps(self.exec_command, out_stream=self.o_stream, err_stream=self.e_stream,
-                                               output_charset=self.output_charset, retry=self.retry, retry_delay=self.retry_delay)
+                                               output_charset=self.output_charset, retry=self.retry, retry_delay=self.retry_delay,
+                                               tracker=self)
                 self.o_std = response.std_out
                 self.e_std = response.std_err
                 self.stat = response.status_code

--- a/plugin.yaml
+++ b/plugin.yaml
@@ -148,6 +148,16 @@ providers:
         required: true
         renderingOptions:
           groupName: Connection
+      - name: terminateonabort
+        title: Terminate On Abort
+        description: "When enabled, aborting a job will terminate the remote command. (Experimental)"
+        type: Boolean
+        default: "false"
+        required: false
+        scope: Instance
+        renderingOptions:
+          groupName: Connection
+          instance-scope-node-attribute: "winrm-terminate-on-abort"
       - name: username
         title: Username
         type: String

--- a/tests/test_winrm_kill.py
+++ b/tests/test_winrm_kill.py
@@ -1,0 +1,197 @@
+"""Unit tests for the abort/kill helpers in contents/winrm_kill.py.
+
+These cover the pure logic (PID capture wrapping, marker parsing/stripping,
+streaming filter and the terminate orchestration) without needing a live
+Windows node. Run with:
+
+    python -m pytest tests/
+    # or
+    python -m unittest discover -s tests
+"""
+
+import os
+import sys
+import unittest
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "contents"))
+
+import winrm_kill  # noqa: E402
+
+
+class PreambleTests(unittest.TestCase):
+    def test_powershell_preamble_uses_pid_variable(self):
+        preamble = winrm_kill.pid_capture_preamble("powershell")
+        self.assertIn(winrm_kill.PID_MARKER, preamble)
+        self.assertIn("$PID", preamble)
+
+    def test_cmd_preamble_uses_single_percent_for_loop(self):
+        preamble = winrm_kill.pid_capture_preamble("cmd")
+        self.assertIn(winrm_kill.PID_MARKER, preamble)
+        # cmd /c one-liner must use single '%', never the batch-file '%%'.
+        self.assertIn("%i", preamble)
+        self.assertNotIn("%%", preamble)
+        self.assertIn("ParentProcessId", preamble)
+
+    def test_wrap_command_powershell_uses_script_block(self):
+        wrapped = winrm_kill.wrap_command("param($x)\nWrite-Host $x", "powershell")
+        self.assertTrue(wrapped.startswith("Write-Output"))
+        self.assertIn(winrm_kill.PID_MARKER, wrapped)
+        self.assertIn("$PID", wrapped)
+        # User script must run inside a script block so a leading param() stays
+        # valid (it becomes the first statement of the block).
+        self.assertIn("& {", wrapped)
+        self.assertIn("param($x)", wrapped)
+
+    def test_wrap_command_cmd_prepends_preamble(self):
+        wrapped = winrm_kill.wrap_command("C:\\tmp\\job.bat", "cmd")
+        self.assertTrue(wrapped.endswith("C:\\tmp\\job.bat"))
+        self.assertIn(winrm_kill.PID_MARKER, wrapped)
+
+
+class ParseTests(unittest.TestCase):
+    def test_parse_remote_pid_basic(self):
+        text = "%s4321\r\n" % winrm_kill.PID_MARKER
+        self.assertEqual(winrm_kill.parse_remote_pid(text), "4321")
+
+    def test_parse_remote_pid_among_other_lines(self):
+        text = "hello\r\n%s99\r\nworld\r\n" % winrm_kill.PID_MARKER
+        self.assertEqual(winrm_kill.parse_remote_pid(text), "99")
+
+    def test_parse_remote_pid_none_when_absent(self):
+        self.assertIsNone(winrm_kill.parse_remote_pid("nothing here"))
+        self.assertIsNone(winrm_kill.parse_remote_pid(""))
+        self.assertIsNone(winrm_kill.parse_remote_pid(None))
+
+    def test_parse_does_not_match_substring_in_other_text(self):
+        # A non-numeric or embedded occurrence must not be captured.
+        text = "see %sNaN for details" % winrm_kill.PID_MARKER
+        self.assertIsNone(winrm_kill.parse_remote_pid(text))
+
+
+class StripTests(unittest.TestCase):
+    def test_strip_marker_line(self):
+        text = "line1\r\n%s555\r\nline2\r\n" % winrm_kill.PID_MARKER
+        self.assertEqual(winrm_kill.strip_pid_marker_lines(text), "line1\r\nline2\r\n")
+
+    def test_strip_is_noop_without_marker(self):
+        text = "just\r\nregular\r\noutput\r\n"
+        self.assertEqual(winrm_kill.strip_pid_marker_lines(text), text)
+
+
+class TaskkillTests(unittest.TestCase):
+    def test_build_taskkill_command(self):
+        self.assertEqual(
+            winrm_kill.build_taskkill_command("777"),
+            "taskkill /F /T /PID 777",
+        )
+
+
+class MarkerFilterTests(unittest.TestCase):
+    def test_captures_pid_and_hides_marker(self):
+        f = winrm_kill.MarkerFilter()
+        out = f.feed("%s1234\r\nreal output\r\n" % winrm_kill.PID_MARKER)
+        self.assertEqual(f.pid, "1234")
+        self.assertNotIn(winrm_kill.PID_MARKER, out)
+        self.assertIn("real output", out)
+
+    def test_marker_split_across_chunks(self):
+        f = winrm_kill.MarkerFilter()
+        # Marker line arrives in two pieces; filter must buffer until newline.
+        part1 = f.feed("%s56" % winrm_kill.PID_MARKER)
+        self.assertEqual(part1, "")  # incomplete line held back
+        self.assertIsNone(f.pid)
+        part2 = f.feed("78\r\nhello\r\n")
+        self.assertEqual(f.pid, "5678")
+        self.assertNotIn(winrm_kill.PID_MARKER, part1 + part2)
+        self.assertIn("hello", part1 + part2)
+
+    def test_flush_emits_buffered_tail(self):
+        f = winrm_kill.MarkerFilter()
+        f.feed("trailing without newline")
+        self.assertEqual(f.flush(), "trailing without newline")
+
+    def test_regular_output_passes_through_unchanged(self):
+        f = winrm_kill.MarkerFilter()
+        out = f.feed("alpha\r\nbeta\r\n")
+        out += f.flush()
+        self.assertEqual(out, "alpha\r\nbeta\r\n")
+        self.assertIsNone(f.pid)
+
+
+class _FakeProtocol(object):
+    def __init__(self):
+        self.cleaned = None
+        self.closed = None
+
+    def cleanup_command(self, shell_id, command_id):
+        self.cleaned = (shell_id, command_id)
+
+    def close_shell(self, shell_id):
+        self.closed = shell_id
+
+
+class _FakeSession(object):
+    def __init__(self):
+        self.killed_with = None
+
+    def run_cmd(self, command):
+        self.killed_with = command
+
+        class _R(object):
+            std_out = b"SUCCESS"
+
+        return _R()
+
+
+class _FakeTracker(object):
+    def __init__(self, pid):
+        self.protocol = _FakeProtocol()
+        self.session = _FakeSession()
+        self.shell_id = "shell-1"
+        self.command_id = "cmd-1"
+        self.remote_pid = pid
+
+
+class _SilentLog(object):
+    def debug(self, *a, **k):
+        pass
+
+    def warning(self, *a, **k):
+        pass
+
+    def error(self, *a, **k):
+        pass
+
+
+class TerminateRemoteTests(unittest.TestCase):
+    def test_terminate_sends_signal_and_taskkill(self):
+        tracker = _FakeTracker("9090")
+        winrm_kill.terminate_remote(tracker, _SilentLog())
+        # WS-Man terminate signal sent for the running command.
+        self.assertEqual(tracker.protocol.cleaned, ("shell-1", "cmd-1"))
+        # Whole process tree force-killed via a fresh shell.
+        self.assertEqual(tracker.session.killed_with, "taskkill /F /T /PID 9090")
+        # Original shell closed.
+        self.assertEqual(tracker.protocol.closed, "shell-1")
+
+    def test_terminate_without_pid_still_sends_signal(self):
+        tracker = _FakeTracker(None)
+        winrm_kill.terminate_remote(tracker, _SilentLog())
+        self.assertEqual(tracker.protocol.cleaned, ("shell-1", "cmd-1"))
+        self.assertIsNone(tracker.session.killed_with)
+        self.assertEqual(tracker.protocol.closed, "shell-1")
+
+    def test_terminate_swallows_taskkill_errors(self):
+        tracker = _FakeTracker("1")
+
+        def boom(_):
+            raise RuntimeError("network down")
+
+        tracker.session.run_cmd = boom
+        # Must not raise even though taskkill fails.
+        winrm_kill.terminate_remote(tracker, _SilentLog())
+        self.assertEqual(tracker.protocol.closed, "shell-1")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
This pull request introduces robust process tree termination for WinRM-executed jobs on Windows nodes, addressing the long-standing issue where aborting a job left remote processes running. The main feature is an optional "Terminate On Abort" mode, which—when enabled—ensures that aborting a job kills both the remote command and all its child processes. This is achieved by capturing the remote process PID and force-killing the process tree on abort. The implementation includes new code for PID capture, output filtering, and remote termination, as well as user-facing documentation and configuration options.

The most important changes are:

**Process Tree Termination Feature:**
* Added a "Terminate On Abort" option to the plugin configuration (`plugin.yaml`, `README.md`). When enabled, aborting a job will terminate the remote command and its entire process tree on the Windows node. This is disabled by default for backward compatibility. [[1]](diffhunk://#diff-d55bf51ed4d80c9c0eef853d64823da5d91fad2e860465f50b40c355fd307afaR151-R160) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R44) [[3]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R180-R210)

**Implementation of Remote PID Capture and Termination:**
* Introduced a new module `winrm_kill.py` that provides:
  - A preamble to print the remote shell's PID,
  - Functions to parse and strip PID marker lines from output,
  - A `MarkerFilter` class for streaming output filtering,
  - Logic to send both the WS-Man terminate signal and a `taskkill` command to kill the entire process tree on abort.

**Integration with Job Execution Flow:**
* Modified `winrm-exec.py` to:
  - Detect the "Terminate On Abort" setting and wrap commands with the PID-capturing preamble,
  - Install signal handlers to catch aborts and trigger remote termination,
  - Filter output to hide PID marker lines and capture the PID,
  - Ensure clean-up and forced exit on abort. [[1]](diffhunk://#diff-77fac413a3f044d5f79a9a67d0c0563bf36b629b362e8849e3a03da3f53acfb4R9-R11) [[2]](diffhunk://#diff-77fac413a3f044d5f79a9a67d0c0563bf36b629b362e8849e3a03da3f53acfb4R145) [[3]](diffhunk://#diff-77fac413a3f044d5f79a9a67d0c0563bf36b629b362e8849e3a03da3f53acfb4R212-R228) [[4]](diffhunk://#diff-77fac413a3f044d5f79a9a67d0c0563bf36b629b362e8849e3a03da3f53acfb4R355-R427) [[5]](diffhunk://#diff-77fac413a3f044d5f79a9a67d0c0563bf36b629b362e8849e3a03da3f53acfb4R438-R443)

**WinRM Session Enhancements:**
* Updated `winrm_session.py` to:
  - Track live WinRM handles and the remote PID for each running command,
  - Allow abort handlers to access these handles and perform remote termination,
  - Pass a tracker object through command execution to enable this coordination. [[1]](diffhunk://#diff-24cbf9625566fa1183a635043d88a8e98f5d6f3135329e5170b8c3f48e55af52L60-R60) [[2]](diffhunk://#diff-24cbf9625566fa1183a635043d88a8e98f5d6f3135329e5170b8c3f48e55af52R90-R118) [[3]](diffhunk://#diff-24cbf9625566fa1183a635043d88a8e98f5d6f3135329e5170b8c3f48e55af52L112-R130) [[4]](diffhunk://#diff-24cbf9625566fa1183a635043d88a8e98f5d6f3135329e5170b8c3f48e55af52R201-R222)

**Documentation:**
* Expanded the `README.md` with a new "Aborting jobs" section, explaining the new behavior, configuration, and technical details for users and operators.

These changes collectively ensure that aborting a WinRM-executed job on Windows nodes can now reliably clean up all spawned processes, improving reliability and resource management.